### PR TITLE
Implement Bodyguard keyword to force targeting

### DIFF
--- a/lib/lorcana/abilities.py
+++ b/lib/lorcana/abilities.py
@@ -16,6 +16,8 @@ def create_printed_abilities(G, card_node: str, card_data: dict, turn: int) -> N
             create_ability(G, card_node, Keyword.EVASIVE, turn)
         elif keyword == 'Alert':
             create_ability(G, card_node, Keyword.ALERT, turn)
+        elif keyword == 'Bodyguard':
+            create_ability(G, card_node, Keyword.BODYGUARD, turn)
 
 
 def create_ability(G, card_node: str, keyword: str, turn: int) -> str:

--- a/lib/lorcana/constants.py
+++ b/lib/lorcana/constants.py
@@ -22,6 +22,7 @@ class Keyword:
     RUSH = "rush"
     EVASIVE = "evasive"
     ALERT = "alert"
+    BODYGUARD = "bodyguard"
 
 
 class Edge:

--- a/lib/lorcana/docs/edges.md
+++ b/lib/lorcana/docs/edges.md
@@ -57,7 +57,11 @@ execute: `execute_quest()` - exert, add lore to player
 ```
 attacker --[action_type=Action.CHALLENGE]--> defender
 ```
-available: `compute_can_challenge()` - attacker ready+(dry or Keyword.RUSH), defender exerted+opponent, Evasive check (attacker needs Evasive or Alert)
+available: `compute_can_challenge()`
+    - attacker ready+(dry or Keyword.RUSH)
+    - defender exerted+opponent
+    - Evasive check (attacker needs Evasive or Alert)
+    - Bodyguard check (must target Bodyguard if able)
 execute: `execute_challenge()` - exert attacker, deal damage both ways
 
 ---

--- a/lib/lorcana/docs/rules/10-keywords.md
+++ b/lib/lorcana/docs/rules/10-keywords.md
@@ -26,3 +26,10 @@ ability --[Keyword.ALERT]--> card
 ```
 knows: `has_keyword(G, card, Keyword.ALERT)`
 effect: `compute_can_challenge()` - can challenge Evasive defenders
+
+### Keyword.BODYGUARD
+```
+ability --[Keyword.BODYGUARD]--> card
+```
+knows: `has_keyword(G, card, Keyword.BODYGUARD)`
+effect: `compute_can_challenge()` - if any valid defender has Bodyguard, must target Bodyguard

--- a/lib/lorcana/mechanics/challenge.py
+++ b/lib/lorcana/mechanics/challenge.py
@@ -45,6 +45,7 @@ def compute_can_challenge(G: nx.MultiDiGraph) -> list[ActionEdge]:
             continue
 
         # Find valid targets (exerted opposing characters)
+        valid_defenders = []
         for defender in opponent_cards:
             defender_data = get_card_data(G, defender)
 
@@ -61,7 +62,15 @@ def compute_can_challenge(G: nx.MultiDiGraph) -> list[ActionEdge]:
                 if not has_keyword(G, challenger, Keyword.EVASIVE) and not has_keyword(G, challenger, Keyword.ALERT):
                     continue
 
-            # Valid challenge!
+            valid_defenders.append(defender)
+
+        # Bodyguard check: if any valid defender has Bodyguard, must target Bodyguard
+        bodyguards = [d for d in valid_defenders if has_keyword(G, d, Keyword.BODYGUARD)]
+        if bodyguards:
+            valid_defenders = bodyguards
+
+        # Create challenge actions for valid targets
+        for defender in valid_defenders:
             result.append(ActionEdge(
                 src=challenger,
                 dst=defender,

--- a/tests/lorcana/test_bodyguard.py
+++ b/tests/lorcana/test_bodyguard.py
@@ -1,0 +1,161 @@
+"""
+Bodyguard Keyword Tests
+=======================
+
+Bodyguard forces opponents to target characters with Bodyguard if able.
+
+OFFICIAL RULES REFERENCE
+------------------------
+Bodyguard: "An opposing character who challenges one of your characters
+must choose one with Bodyguard if able."
+
+GRAPH DESIGN
+------------
+Printed Bodyguard creates: ability --[Keyword.BODYGUARD]--> card
+Challenge logic filters valid defenders to only Bodyguard characters when present.
+"""
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from tests.lorcana.conftest import make_game, add_character, set_turn
+from lib.lorcana.constants import Zone
+from lib.lorcana.mechanics.challenge import compute_can_challenge
+
+
+class TestBodyguard:
+    """Characters with Bodyguard must be challenged if able."""
+
+    def test_must_challenge_bodyguard_when_exerted(self):
+        """
+        SCENARIO: With both exerted Bodyguard and non-Bodyguard present,
+        only Bodyguard becomes a valid target.
+
+        SETUP:
+        - Stitch (attacker, no keywords) is ready and dry
+        - Simba (has Bodyguard) is exerted
+        - Stitch New Dog (no Bodyguard) is exerted
+
+        EXPECTED:
+        - Only Simba (Bodyguard) can be challenged
+        """
+        G = make_game()
+        set_turn(G, 3)
+
+        attacker = add_character(G, 'p1', 'stitch_rock_star',
+            zone=Zone.PLAY,
+            exerted=False,
+            entered_play=2
+        )
+
+        bodyguard = add_character(G, 'p2', 'simba_protective_cub',
+            zone=Zone.PLAY,
+            exerted=True,
+            entered_play=2
+        )
+
+        add_character(G, 'p2', 'stitch_new_dog',
+            zone=Zone.PLAY,
+            exerted=True,
+            entered_play=2
+        )
+
+        actions = compute_can_challenge(G)
+
+        assert len(actions) == 1, "Must challenge Bodyguard when present"
+        assert actions[0].src == attacker
+        assert actions[0].dst == bodyguard
+
+    def test_ready_bodyguard_doesnt_restrict(self):
+        """
+        SCENARIO: A ready (non-exerted) Bodyguard doesn't limit target selection.
+
+        SETUP:
+        - Stitch (attacker) is ready and dry
+        - Simba (has Bodyguard) is ready (not exerted)
+        - Stitch New Dog (no Bodyguard) is exerted
+
+        EXPECTED:
+        - Can challenge Stitch New Dog (Bodyguard not exerted, so not "able")
+        """
+        G = make_game()
+        set_turn(G, 3)
+
+        attacker = add_character(G, 'p1', 'stitch_rock_star',
+            zone=Zone.PLAY,
+            exerted=False,
+            entered_play=2
+        )
+
+        add_character(G, 'p2', 'simba_protective_cub',
+            zone=Zone.PLAY,
+            exerted=False,  # Ready, not a valid target
+            entered_play=2
+        )
+
+        non_bodyguard = add_character(G, 'p2', 'stitch_new_dog',
+            zone=Zone.PLAY,
+            exerted=True,
+            entered_play=2
+        )
+
+        actions = compute_can_challenge(G)
+
+        assert len(actions) == 1, "Ready Bodyguard doesn't restrict targets"
+        assert actions[0].src == attacker
+        assert actions[0].dst == non_bodyguard
+
+    def test_multiple_bodyguards_all_valid(self):
+        """
+        SCENARIO: Multiple exerted Bodyguards all remain valid targets.
+
+        SETUP:
+        - Stitch (attacker) is ready and dry
+        - Two Simbas (both have Bodyguard) are exerted
+
+        EXPECTED:
+        - Both Bodyguards are valid challenge targets
+        """
+        G = make_game()
+        set_turn(G, 3)
+
+        attacker = add_character(G, 'p1', 'stitch_rock_star',
+            zone=Zone.PLAY,
+            exerted=False,
+            entered_play=2
+        )
+
+        # Add first bodyguard with unique node id
+        bodyguard1 = 'p2.simba_protective_cub.a'
+        G.add_node(bodyguard1,
+            type='card',
+            label='simba_protective_cub',
+            zone=Zone.PLAY,
+            exerted='1',
+            damage='0',
+            entered_play='2'
+        )
+        from lib.lorcana.cards import get_card_db
+        from lib.lorcana.abilities import create_printed_abilities
+        card_db = get_card_db()
+        create_printed_abilities(G, bodyguard1, card_db['simba_protective_cub'], 2)
+
+        # Add second bodyguard with different node id
+        bodyguard2 = 'p2.simba_protective_cub.b'
+        G.add_node(bodyguard2,
+            type='card',
+            label='simba_protective_cub',
+            zone=Zone.PLAY,
+            exerted='1',
+            damage='0',
+            entered_play='2'
+        )
+        create_printed_abilities(G, bodyguard2, card_db['simba_protective_cub'], 2)
+
+        actions = compute_can_challenge(G)
+
+        assert len(actions) == 2, "Multiple Bodyguards all valid"
+        targets = {a.dst for a in actions}
+        assert bodyguard1 in targets
+        assert bodyguard2 in targets
+        assert all(a.src == attacker for a in actions)


### PR DESCRIPTION

  Bodyguard protects allies by requiring opponents to target characters
  with Bodyguard when challenging, if any valid Bodyguard target exists.

  - Add BODYGUARD constant to Keyword class
  - Detect Bodyguard keyword when creating printed abilities
  - Refactor challenge logic to collect valid defenders, then filter to
    Bodyguard-only when present
  - Add tests for mandatory targeting, ready Bodyguard bypass, and
    multiple Bodyguards
  - Update keyword and edge documentation

  Closes https://github.com/kpom-one/graph-trajectories/issues/4