### PR TITLE
  Implement Bodyguard play exerted option

### DIFF
--- a/lib/lorcana/compute.py
+++ b/lib/lorcana/compute.py
@@ -35,9 +35,12 @@ def _clear_can_edges(G: nx.MultiDiGraph) -> None:
         G.remove_edge(*edge)
 
 
-def _add_can_edge(G: nx.MultiDiGraph, src: str, dst: str, action_type: str, action_id: str, description: str) -> str:
-    """Add an action edge with sequential action_id and description."""
-    key = G.add_edge(src, dst, action_type=action_type, action_id=action_id, description=description)
+def _add_can_edge(G: nx.MultiDiGraph, src: str, dst: str, action_type: str, action_id: str, description: str, metadata: dict | None = None) -> str:
+    """Add an action edge with sequential action_id, description, and optional metadata."""
+    edge_attrs = {'action_type': action_type, 'action_id': action_id, 'description': description}
+    if metadata:
+        edge_attrs.update(metadata)
+    key = G.add_edge(src, dst, **edge_attrs)
     return key
 
 
@@ -65,4 +68,4 @@ def compute_all(G: nx.MultiDiGraph) -> None:
 
     # Add edges with sequential action_ids (base-36 for compactness)
     for idx, edge in enumerate(sorted_edges):
-        _add_can_edge(G, edge.src, edge.dst, edge.action_type, action_id=_to_base36(idx), description=edge.description)
+        _add_can_edge(G, edge.src, edge.dst, edge.action_type, action_id=_to_base36(idx), description=edge.description, metadata=edge.metadata)

--- a/lib/lorcana/docs/edges.md
+++ b/lib/lorcana/docs/edges.md
@@ -42,9 +42,10 @@ execute: `execute_ink()` - move to ink zone, increment ink counters
 ### Action.PLAY
 ```
 card --[action_type=Action.PLAY]--> player
+card --[action_type=Action.PLAY, exerted=True]--> player  # Bodyguard option
 ```
-available: `compute_can_play()` - card in hand, ink_available >= cost
-execute: `execute_play()` - move to play/discard, spend ink, set entered_play
+available: `compute_can_play()` - card in hand, ink_available >= cost; Bodyguard cards get two edges
+execute: `execute_play()` - move to play/discard, spend ink, set entered_play (exerted if metadata.exerted)
 
 ### Action.QUEST
 ```

--- a/lib/lorcana/docs/rules/10-keywords.md
+++ b/lib/lorcana/docs/rules/10-keywords.md
@@ -31,5 +31,7 @@ effect: `compute_can_challenge()` - can challenge Evasive defenders
 ```
 ability --[Keyword.BODYGUARD]--> card
 ```
-knows: `has_keyword(G, card, Keyword.BODYGUARD)`
-effect: `compute_can_challenge()` - if any valid defender has Bodyguard, must target Bodyguard
+knows: `has_keyword(G, card, Keyword.BODYGUARD)` or `card_data_has_keyword(card_data, 'Bodyguard')` (in hand)
+effect:
+- `compute_can_play()` - adds second play option with `exerted=True` metadata
+- `compute_can_challenge()` - if any valid defender has Bodyguard, must target Bodyguard

--- a/lib/lorcana/execute.py
+++ b/lib/lorcana/execute.py
@@ -21,14 +21,15 @@ from lib.lorcana.state_based_effects import check_state_based_effects
 from lib.lorcana.constants import Action
 
 
-def execute_action(state: LorcanaState, action_type: str, from_node: str, to_node: str) -> None:
+def execute_action(state: LorcanaState, action_type: str, from_node: str, to_node: str, metadata: dict | None = None) -> None:
     """Execute an action, mutating the state."""
+    metadata = metadata or {}
     if action_type == Action.PASS:
         advance_turn(state, from_node, to_node)
     elif action_type == Action.INK:
         execute_ink(state, from_node)
     elif action_type == Action.PLAY:
-        execute_play(state, from_node, to_node)
+        execute_play(state, from_node, to_node, metadata)
     elif action_type == Action.QUEST:
         execute_quest(state, from_node, to_node)
     elif action_type == Action.CHALLENGE:
@@ -74,8 +75,11 @@ def apply_action_at_path(path: Path) -> None:
         if edge_action_id == action_id:
             # Get description before applying (edge will be removed)
             action_desc = get_edge_attr(parent.graph, u, v, key, "description", f"{action_type}:{u}")
+            # Collect metadata from edge (non-standard attributes)
+            edge_data = parent.graph.edges[u, v, key]
+            metadata = {k: v for k, v in edge_data.items() if k not in ('action_type', 'action_id', 'description')}
             # Apply the action (mutates parent.graph)
-            execute_action(parent, action_type, u, v)
+            execute_action(parent, action_type, u, v, metadata)
             action_found = True
             break
 

--- a/lib/lorcana/helpers.py
+++ b/lib/lorcana/helpers.py
@@ -19,6 +19,7 @@ class ActionEdge(NamedTuple):
     dst: str          # Target node (e.g., player, or defender for challenge)
     action_type: str  # Type of action (CAN_CHALLENGE, CAN_QUEST, etc.)
     description: str  # Human-readable description for UI
+    metadata: dict | None = None  # Action-specific attributes (e.g., {'exerted': True} for Bodyguard)
 
 
 def get_player_step(player: str, step: str) -> str:
@@ -117,5 +118,25 @@ def has_keyword(G, card_node: str, keyword: str) -> bool:
     """
     for u, v, data in G.in_edges(card_node, data=True):
         if data.get('label') == keyword:
+            return True
+    return False
+
+
+def card_data_has_keyword(card_data: dict, keyword: str) -> bool:
+    """
+    Check if card data contains a specific keyword.
+
+    Use this for cards not yet in play (e.g., in hand) where ability
+    nodes don't exist yet. For cards in play, use has_keyword() instead.
+
+    Args:
+        card_data: Card data dict from card database
+        keyword: Keyword name as it appears in card data (e.g., 'Bodyguard', 'Shift')
+
+    Returns:
+        True if card has the keyword in its abilities
+    """
+    for ability in card_data.get('abilities', []):
+        if ability.get('keyword') == keyword:
             return True
     return False

--- a/tests/lorcana/test_bodyguard_play.py
+++ b/tests/lorcana/test_bodyguard_play.py
@@ -1,0 +1,125 @@
+"""
+Bodyguard Play Exerted Tests
+============================
+
+Bodyguard characters may optionally enter play exerted.
+
+OFFICIAL RULES REFERENCE
+------------------------
+Bodyguard: "This character may enter play exerted."
+
+GRAPH DESIGN
+------------
+Bodyguard cards get two CAN_PLAY edges:
+- Normal: card --[action_type=Action.PLAY]--> player
+- Exerted: card --[action_type=Action.PLAY, exerted=True]--> player
+"""
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from tests.lorcana.conftest import make_game, add_character, make_state, give_ink
+from lib.lorcana.constants import Zone, Action
+from lib.lorcana.mechanics.play import compute_can_play, execute_play
+
+
+class TestBodyguardPlayOptions:
+    """Bodyguard cards have two play options."""
+
+    def test_bodyguard_shows_two_play_options(self):
+        """
+        SCENARIO: Bodyguard cards display two CAN_PLAY options.
+
+        SETUP:
+        - Player has Simba (Bodyguard) in hand
+        - Player has enough ink
+
+        EXPECTED:
+        - Two play actions available for Simba
+        - One normal, one with exerted metadata
+        """
+        G = make_game()
+        give_ink(G, 'p1', 2)  # Simba costs 2
+        simba = add_character(G, 'p1', 'simba_protective_cub', zone=Zone.HAND)
+
+        actions = compute_can_play(G)
+
+        simba_actions = [a for a in actions if a.src == simba]
+        assert len(simba_actions) == 2, "Bodyguard should have two play options"
+
+        # One should be normal (no metadata or exerted=False)
+        normal = [a for a in simba_actions if not a.metadata or not a.metadata.get('exerted')]
+        assert len(normal) == 1, "Should have one normal play option"
+        assert normal[0].description == f"play:{simba}"
+
+        # One should be exerted
+        exerted = [a for a in simba_actions if a.metadata and a.metadata.get('exerted')]
+        assert len(exerted) == 1, "Should have one exerted play option"
+        assert exerted[0].description == f"play:{simba}:exerted"
+
+    def test_non_bodyguard_has_single_play_option(self):
+        """
+        SCENARIO: Non-bodyguard cards have only one play option.
+
+        SETUP:
+        - Player has Stitch (no Bodyguard) in hand
+        - Player has enough ink
+
+        EXPECTED:
+        - Only one play action available
+        """
+        G = make_game()
+        give_ink(G, 'p1', 4)  # Stitch New Dog costs 4
+        stitch = add_character(G, 'p1', 'stitch_new_dog', zone=Zone.HAND)
+
+        actions = compute_can_play(G)
+
+        stitch_actions = [a for a in actions if a.src == stitch]
+        assert len(stitch_actions) == 1, "Non-bodyguard should have one play option"
+        assert stitch_actions[0].metadata is None or not stitch_actions[0].metadata.get('exerted')
+
+
+class TestBodyguardPlayExecution:
+    """Bodyguard play modes set correct exerted state."""
+
+    def test_normal_play_enters_ready(self):
+        """
+        SCENARIO: Normal play mode enters ready state.
+
+        SETUP:
+        - Player plays Simba normally (no exerted metadata)
+
+        EXPECTED:
+        - Simba enters play ready (exerted='0')
+        """
+        G = make_game()
+        give_ink(G, 'p1', 2)
+        simba = add_character(G, 'p1', 'simba_protective_cub', zone=Zone.HAND)
+        state = make_state(G)
+
+        # Execute normal play (no metadata)
+        execute_play(state, simba, 'p1', metadata=None)
+
+        assert G.nodes[simba]['zone'] == Zone.PLAY
+        assert G.nodes[simba]['exerted'] == '0', "Normal play should enter ready"
+
+    def test_bodyguard_play_exerted_enters_exerted(self):
+        """
+        SCENARIO: Bodyguard exerted play mode enters exerted state.
+
+        SETUP:
+        - Player plays Simba with exerted=True metadata
+
+        EXPECTED:
+        - Simba enters play exerted (exerted='1')
+        """
+        G = make_game()
+        give_ink(G, 'p1', 2)
+        simba = add_character(G, 'p1', 'simba_protective_cub', zone=Zone.HAND)
+        state = make_state(G)
+
+        # Execute bodyguard play (with exerted metadata)
+        execute_play(state, simba, 'p1', metadata={'exerted': True})
+
+        assert G.nodes[simba]['zone'] == Zone.PLAY
+        assert G.nodes[simba]['exerted'] == '1', "Bodyguard exerted play should enter exerted"


### PR DESCRIPTION
  Bodyguard characters can optionally enter play exerted, enabling
  immediate protection via the Bodyguard targeting restriction.

  - Add metadata dict to ActionEdge for action-specific attributes
  - Spread metadata onto graph edges and pass through execute chain
  - Bodyguard cards emit two play options: normal and exerted
  - execute_play checks metadata to set exerted state on entry

  Closes #5