### PR TITLE
  Implement Reckless keyword to prevent questing

### DIFF
--- a/lib/lorcana/abilities.py
+++ b/lib/lorcana/abilities.py
@@ -18,6 +18,9 @@ def create_printed_abilities(G, card_node: str, card_data: dict, turn: int) -> N
             create_ability(G, card_node, Keyword.ALERT, turn)
         elif keyword == 'Bodyguard':
             create_ability(G, card_node, Keyword.BODYGUARD, turn)
+        elif keyword == 'Reckless':
+            ability_id = create_ability(G, card_node, Keyword.RECKLESS, turn)
+            G.add_edge(ability_id, card_node, label=Edge.CANT_QUEST)
 
 
 def create_ability(G, card_node: str, keyword: str, turn: int) -> str:

--- a/lib/lorcana/constants.py
+++ b/lib/lorcana/constants.py
@@ -23,6 +23,7 @@ class Keyword:
     EVASIVE = "evasive"
     ALERT = "alert"
     BODYGUARD = "bodyguard"
+    RECKLESS = "reckless"
 
 
 class Edge:
@@ -30,6 +31,7 @@ class Edge:
     SOURCE = "source"
     CURRENT_TURN = "current_turn"
     CURRENT_STEP = "current_step"
+    CANT_QUEST = "cant_quest"
 
 
 class Step:

--- a/lib/lorcana/docs/edges.md
+++ b/lib/lorcana/docs/edges.md
@@ -51,7 +51,7 @@ execute: `execute_play()` - move to play/discard, spend ink, set entered_play (e
 ```
 card --[action_type=Action.QUEST]--> player
 ```
-available: `compute_can_quest()` - in play, ready, dry (entered_play < current_turn)
+available: `compute_can_quest()` - in play, ready, dry (entered_play < current_turn), no CANT_QUEST edge
 execute: `execute_quest()` - exert, add lore to player
 
 ### Action.CHALLENGE
@@ -64,6 +64,20 @@ available: `compute_can_challenge()`
     - Evasive check (attacker needs Evasive or Alert)
     - Bodyguard check (must target Bodyguard if able)
 execute: `execute_challenge()` - exert attacker, deal damage both ways
+
+---
+
+## Effect
+
+Edges that modify game rules. Created by abilities.
+
+### Edge.CANT_QUEST
+```
+ability --[Edge.CANT_QUEST]--> card
+```
+knows: `has_edge(G, card, Edge.CANT_QUEST)`
+created by: Reckless keyword
+effect: `compute_can_quest()` - blocks quest action
 
 ---
 

--- a/lib/lorcana/docs/rules/10-keywords.md
+++ b/lib/lorcana/docs/rules/10-keywords.md
@@ -35,3 +35,11 @@ knows: `has_keyword(G, card, Keyword.BODYGUARD)` or `card_data_has_keyword(card_
 effect:
 - `compute_can_play()` - adds second play option with `exerted=True` metadata
 - `compute_can_challenge()` - if any valid defender has Bodyguard, must target Bodyguard
+
+### Keyword.RECKLESS
+```
+ability --[Keyword.RECKLESS]--> card
+ability --[Edge.CANT_QUEST]--> card
+```
+knows: `has_keyword(G, card, Keyword.RECKLESS)` or `has_edge(G, card, Edge.CANT_QUEST)`
+effect: `compute_can_quest()` - blocked by CANT_QUEST edge

--- a/lib/lorcana/helpers.py
+++ b/lib/lorcana/helpers.py
@@ -116,8 +116,23 @@ def has_keyword(G, card_node: str, keyword: str) -> bool:
     Returns:
         True if any edge with that label points to the card
     """
+    return has_edge(G, card_node, keyword)
+
+
+def has_edge(G, card_node: str, label: str) -> bool:
+    """
+    Check if a card has an incoming edge with the given label.
+
+    Args:
+        G: Game graph
+        card_node: Card node ID
+        label: Edge label to check for (e.g., Edge.CANT_QUEST, Keyword.RUSH)
+
+    Returns:
+        True if any edge with that label points to the card
+    """
     for u, v, data in G.in_edges(card_node, data=True):
-        if data.get('label') == keyword:
+        if data.get('label') == label:
             return True
     return False
 

--- a/lib/lorcana/mechanics/quest.py
+++ b/lib/lorcana/mechanics/quest.py
@@ -5,8 +5,8 @@ Compute when characters can quest, and execute the quest action.
 """
 import networkx as nx
 from lib.core.graph import get_node_attr
-from lib.lorcana.constants import Zone, Action, CardType
-from lib.lorcana.helpers import ActionEdge, get_game_context, get_card_data, cards_in_zone
+from lib.lorcana.constants import Zone, Action, CardType, Edge
+from lib.lorcana.helpers import ActionEdge, get_game_context, get_card_data, cards_in_zone, has_edge
 
 
 def compute_can_quest(G: nx.MultiDiGraph) -> list[ActionEdge]:
@@ -37,6 +37,10 @@ def compute_can_quest(G: nx.MultiDiGraph) -> list[ActionEdge]:
         # Must be dry (entered play before this turn)
         entered_play = int(get_node_attr(G, card_node, 'entered_play', '-1'))
         if entered_play == ctx['current_turn']:
+            continue
+
+        # Check for CANT_QUEST edge (e.g., from Reckless keyword)
+        if has_edge(G, card_node, Edge.CANT_QUEST):
             continue
 
         result.append(ActionEdge(

--- a/tests/lorcana/test_quest.py
+++ b/tests/lorcana/test_quest.py
@@ -240,8 +240,8 @@ class TestZeroLore:
               This matters for "whenever this character quests" triggers.
         """
         G = make_game()
-        # Gaston - Arrogant Hunter has 0 lore (he's Reckless, meant for combat)
-        gaston = add_character(G, 'p1', 'gaston_arrogant_hunter',
+        # The Queen - Disguised Peddler has 0 lore
+        queen = add_character(G, 'p1', 'the_queen_disguised_peddler',
             zone=Zone.PLAY,
             exerted=False,
             entered_play=0
@@ -250,7 +250,7 @@ class TestZeroLore:
         actions = compute_can_quest(G)
 
         assert len(actions) == 1, "Character with 0 lore CAN quest"
-        assert actions[0].src == gaston
+        assert actions[0].src == queen
 
     def test_questing_with_zero_lore_gains_nothing(self):
         """
@@ -258,27 +258,27 @@ class TestZeroLore:
 
         SETUP:
         - Player has 5 lore
-        - Gaston (0 lore) quests
+        - The Queen (0 lore) quests
 
         EXPECTED:
         - Player still has 5 lore (gained 0)
-        - Gaston is exerted
+        - The Queen is exerted
 
         RULE: 4.3.5.8 - You gain lore equal to {L}. If {L} is 0, you gain 0.
         """
         G = make_game()
         G.nodes['p1']['lore'] = '5'
-        gaston = add_character(G, 'p1', 'gaston_arrogant_hunter',
+        queen = add_character(G, 'p1', 'the_queen_disguised_peddler',
             zone=Zone.PLAY,
             exerted=False,
             entered_play=0
         )
         state = make_state(G)
 
-        execute_quest(state, gaston, 'p1')
+        execute_quest(state, queen, 'p1')
 
         assert G.nodes['p1']['lore'] == '5', "Should gain 0 lore"
-        assert G.nodes[gaston]['exerted'] == '1', "Should still exert"
+        assert G.nodes[queen]['exerted'] == '1', "Should still exert"
 
 
 # =============================================================================

--- a/tests/lorcana/test_reckless.py
+++ b/tests/lorcana/test_reckless.py
@@ -1,0 +1,98 @@
+"""
+Reckless Keyword Tests
+======================
+
+Reckless prevents characters from questing.
+
+OFFICIAL RULES REFERENCE
+------------------------
+Reckless: "This character can't quest and must challenge each turn if able."
+
+GRAPH DESIGN
+------------
+Printed Reckless creates:
+- ability --[Keyword.RECKLESS]--> card
+- ability --[Edge.CANT_QUEST]--> card
+
+Quest logic checks for CANT_QUEST edge and blocks quest action.
+"""
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from tests.lorcana.conftest import make_game, add_character, set_turn
+from lib.lorcana.constants import Zone, Edge
+from lib.lorcana.mechanics.quest import compute_can_quest
+from lib.lorcana.helpers import has_edge
+
+
+class TestReckless:
+    """Characters with Reckless cannot quest."""
+
+    def test_reckless_cannot_quest(self):
+        """
+        SCENARIO: A character with Reckless cannot quest.
+
+        SETUP:
+        - Gaston (has Reckless) is ready and dry
+
+        EXPECTED:
+        - Gaston CANNOT quest
+        """
+        G = make_game()
+        set_turn(G, 3)
+
+        add_character(G, 'p1', 'gaston_arrogant_hunter',
+            zone=Zone.PLAY,
+            exerted=False,
+            entered_play=2
+        )
+
+        actions = compute_can_quest(G)
+
+        assert len(actions) == 0, "Reckless character cannot quest"
+
+    def test_non_reckless_can_quest(self):
+        """
+        SCENARIO: A character without Reckless can quest normally.
+
+        SETUP:
+        - Stitch (no Reckless) is ready and dry
+
+        EXPECTED:
+        - Stitch CAN quest
+        """
+        G = make_game()
+        set_turn(G, 3)
+
+        stitch = add_character(G, 'p1', 'stitch_new_dog',
+            zone=Zone.PLAY,
+            exerted=False,
+            entered_play=2
+        )
+
+        actions = compute_can_quest(G)
+
+        assert len(actions) == 1, "Non-reckless character can quest"
+        assert actions[0].src == stitch
+
+    def test_cant_quest_edge_created_on_play(self):
+        """
+        SCENARIO: CANT_QUEST edge is created when Reckless character enters play.
+
+        SETUP:
+        - Gaston (has Reckless) is in play
+
+        EXPECTED:
+        - Gaston has a CANT_QUEST edge pointing to it
+        """
+        G = make_game()
+        set_turn(G, 3)
+
+        gaston = add_character(G, 'p1', 'gaston_arrogant_hunter',
+            zone=Zone.PLAY,
+            exerted=False,
+            entered_play=2
+        )
+
+        assert has_edge(G, gaston, Edge.CANT_QUEST), "Reckless should create CANT_QUEST edge"


### PR DESCRIPTION
  Reckless characters can't quest, forcing them into combat. This creates
  the CANT_QUEST effect edge pattern for blocking specific actions.

  - Add Keyword.RECKLESS and Edge.CANT_QUEST constants
  - Add reusable has_edge() helper, refactor has_keyword() to use it
  - Reckless creates both keyword and CANT_QUEST edges on play
  - Quest computation checks for CANT_QUEST edge
  - Fix 0-lore quest tests to use non-Reckless character
  - Document keyword and effect edge

  Closes #7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced the Reckless keyword ability, which prevents cards with this keyword from questing.

* **Documentation**
  * Updated documentation to describe the Reckless keyword and its effect on quest eligibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->