### PR TITLE
feat: add per-card trajectory narratives with batch generation (#37)

### DIFF
--- a/bin/build-narratives.py
+++ b/bin/build-narratives.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""
+Build narrative files for all cards across episodes.
+
+Generates narrative stories for each card and organizes them by card type.
+
+Usage:
+    python bin/build-narratives.py                    # Process all episodes
+    python bin/build-narratives.py <episode_path>    # Process single episode
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+# Import from sibling scripts
+from importlib.util import spec_from_file_location, module_from_spec
+
+
+def load_module(name: str, path: Path):
+    """Load a Python module from a file path."""
+    spec = spec_from_file_location(name, path)
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# Load sibling modules
+build_trajectories_mod = load_module(
+    "build_trajectories",
+    Path(__file__).parent / "build-trajectories.py"
+)
+trajectory_story_mod = load_module(
+    "trajectory_story",
+    Path(__file__).parent / "trajectory-story.py"
+)
+
+build_trajectories = build_trajectories_mod.build_trajectories
+generate_narrative = trajectory_story_mod.generate_narrative
+
+
+def extract_card_label(card_id: str) -> str:
+    """Extract card label from card_id: p2.mulan_free_spirit.b -> mulan_free_spirit"""
+    parts = card_id.split(".")
+    if len(parts) >= 2:
+        return parts[1]
+    return card_id
+
+
+def extract_instance_parts(card_id: str) -> tuple[str, str]:
+    """Extract player and instance from card_id: p2.mulan_free_spirit.b -> (p2, b)"""
+    parts = card_id.split(".")
+    if len(parts) >= 3:
+        return parts[0], parts[2]
+    elif len(parts) == 2:
+        return parts[0], "a"
+    return "p1", "a"
+
+
+def get_episode_id(episode_path: Path) -> str:
+    """Extract episode ID from path: output/episodes/0xuebtpz-1.episode -> 0xuebtpz-1"""
+    name = episode_path.name
+    if name.endswith(".episode"):
+        return name[:-8]
+    return name
+
+
+def get_card_trajectories(episode_path: Path) -> list[str]:
+    """Get list of card IDs that have trajectory files."""
+    traj_dir = episode_path / "trajectories"
+    if not traj_dir.exists():
+        return []
+
+    card_ids = []
+    for f in traj_dir.glob("*.jsonl"):
+        if f.name != "game.jsonl":
+            card_ids.append(f.stem)
+
+    return sorted(card_ids)
+
+
+def ensure_trajectories(episode_path: Path) -> bool:
+    """Ensure trajectories exist for episode, building if needed."""
+    traj_dir = episode_path / "trajectories"
+    game_jsonl = traj_dir / "game.jsonl"
+
+    if game_jsonl.exists():
+        return True
+
+    print(f"  Building trajectories for {episode_path.name}...")
+    try:
+        build_trajectories(episode_path)
+        return True
+    except Exception as e:
+        print(f"  Error building trajectories: {e}")
+        return False
+
+
+def process_episode(episode_path: Path, output_base: Path) -> int:
+    """Process a single episode, generating narratives for all cards.
+
+    Returns number of narratives generated.
+    """
+    episode_id = get_episode_id(episode_path)
+
+    # Ensure trajectories exist
+    if not ensure_trajectories(episode_path):
+        return 0
+
+    # Get all card trajectories
+    card_ids = get_card_trajectories(episode_path)
+    if not card_ids:
+        print(f"  No card trajectories found in {episode_path.name}")
+        return 0
+
+    count = 0
+    for card_id in card_ids:
+        try:
+            # Generate narrative
+            narrative = generate_narrative(episode_path, card_id)
+
+            # Determine output path
+            card_label = extract_card_label(card_id)
+            player, instance = extract_instance_parts(card_id)
+
+            output_dir = output_base / card_label
+            output_dir.mkdir(parents=True, exist_ok=True)
+
+            output_file = output_dir / f"{episode_id}.{player}.{instance}.txt"
+            output_file.write_text(narrative)
+
+            count += 1
+        except Exception as e:
+            print(f"  Error processing {card_id}: {e}")
+
+    return count
+
+
+def find_all_episodes(base_path: Path = None) -> list[Path]:
+    """Find all episode directories."""
+    if base_path is None:
+        base_path = Path("output/episodes")
+
+    if not base_path.exists():
+        return []
+
+    return sorted(base_path.glob("*.episode"))
+
+
+def main():
+    output_base = Path("output/narratives")
+
+    if len(sys.argv) >= 2:
+        # Process single episode
+        episode_path = Path(sys.argv[1])
+        if not episode_path.exists():
+            print(f"Error: {episode_path} does not exist")
+            sys.exit(1)
+
+        episodes = [episode_path]
+    else:
+        # Process all episodes
+        episodes = find_all_episodes()
+        if not episodes:
+            print("No episodes found in output/episodes/")
+            sys.exit(1)
+
+    total_narratives = 0
+
+    for episode_path in episodes:
+        print(f"Processing {episode_path.name}...")
+        count = process_episode(episode_path, output_base)
+        total_narratives += count
+        print(f"  Generated {count} narratives")
+
+    print(f"\nTotal: {total_narratives} narratives in {output_base}/")
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/build-trajectories.py
+++ b/bin/build-trajectories.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""
+Extract per-card trajectory files from an episode.
+
+Each card gets one .jsonl file with exactly N lines (one per state).
+Each line contains: node attributes, edges, and global game state.
+
+Usage:
+    python bin/build-trajectories.py output/episodes/abc.episode
+"""
+import sys
+import json
+import re
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from lib.core.graph import load_dot
+
+
+def clean_value(val):
+    """Strip extra quotes from DOT-parsed values."""
+    if isinstance(val, str):
+        return val.strip('"')
+    return val
+
+
+def clean_dict(d: dict) -> dict:
+    """Clean all values in a dict."""
+    return {k: clean_value(v) for k, v in d.items()}
+
+
+def parse_actions_from_history(episode_path: Path) -> list[str]:
+    """Extract action names from history.txt."""
+    history_path = episode_path / "history.txt"
+    actions = []
+
+    if not history_path.exists():
+        return actions
+
+    content = history_path.read_text()
+    for match in re.finditer(r"# action: (.+)", content):
+        actions.append(match.group(1).strip())
+
+    return actions
+
+
+def extract_game_state(graph, state_index: int) -> dict:
+    """Extract global game state at a given state index."""
+    game_node = f"game@{state_index}"
+    p1_node = f"p1@{state_index}"
+    p2_node = f"p2@{state_index}"
+
+    game_attrs = clean_dict(graph.nodes.get(game_node, {}))
+    p1_attrs = clean_dict(graph.nodes.get(p1_node, {}))
+    p2_attrs = clean_dict(graph.nodes.get(p2_node, {}))
+
+    # Find current player from CURRENT_TURN edge
+    current_player = None
+    for u, v, data in graph.edges(data=True):
+        if u == game_node and data.get("label") == "CURRENT_TURN":
+            current_player = v.replace(f"@{state_index}", "")
+            break
+
+    return {
+        "turn": game_attrs.get("turn", "0"),
+        "game_over": game_attrs.get("game_over", "0"),
+        "winner": game_attrs.get("winner"),
+        "current_player": current_player,
+        "p1_lore": p1_attrs.get("lore", "0"),
+        "p2_lore": p2_attrs.get("lore", "0"),
+    }
+
+
+def extract_node_state(graph, base_id: str, state_index: int) -> dict | None:
+    """Extract a node's state at a given state index."""
+    node_id = f"{base_id}@{state_index}"
+
+    if node_id not in graph.nodes:
+        return None
+
+    return clean_dict(graph.nodes[node_id])
+
+
+def extract_node_edges(graph, base_id: str, state_index: int) -> list[str]:
+    """Extract outgoing action edge types for a node."""
+    node_id = f"{base_id}@{state_index}"
+
+    edges = []
+    for u, v, data in graph.edges(data=True):
+        if u == node_id:
+            if data.get("label") == "next":
+                continue
+            action_type = clean_value(data.get("action_type", ""))
+            if action_type:
+                edges.append(action_type)
+
+    return edges
+
+
+def determine_role(action: str, card_id: str, prev_state: dict | None, curr_state: dict | None) -> str:
+    """Determine the card's role in this action.
+
+    Returns: "actor" | "target" | "byproduct" | "observer"
+    """
+    # Check if this card is the actor (action contains card_id before any ->)
+    if "->" in action:
+        actor_part = action.split("->")[0]
+        target_part = action.split("->")[1]
+        if card_id in actor_part:
+            return "actor"
+        if card_id in target_part:
+            return "target"
+    elif card_id in action:
+        return "actor"
+
+    # Check if state changed (byproduct)
+    if prev_state and curr_state:
+        if (prev_state.get("zone") != curr_state.get("zone") or
+            prev_state.get("exerted") != curr_state.get("exerted") or
+            prev_state.get("damage") != curr_state.get("damage")):
+            return "byproduct"
+    elif prev_state is None and curr_state is not None:
+        # Card just appeared (drawn)
+        return "byproduct"
+    elif prev_state is not None and curr_state is None:
+        # Card just disappeared (banished/inked)
+        return "byproduct"
+
+    return "observer"
+
+
+def get_all_card_ids(graph) -> set[str]:
+    """Get all unique card base IDs (without @N suffix)."""
+    card_ids = set()
+
+    for node, attrs in graph.nodes(data=True):
+        if attrs.get("type") == "Card" and "@" in node:
+            base_id = node.rsplit("@", 1)[0]
+            card_ids.add(base_id)
+
+    return card_ids
+
+
+def get_max_state_index(graph) -> int:
+    """Find the highest state index in the graph."""
+    max_idx = 0
+    for node in graph.nodes():
+        if "@" in node:
+            try:
+                idx = int(node.rsplit("@", 1)[1])
+                max_idx = max(max_idx, idx)
+            except ValueError:
+                pass
+    return max_idx
+
+
+def build_trajectories(episode_path: Path) -> Path:
+    """
+    Build trajectory files for all cards in an episode.
+
+    Returns path to trajectories directory.
+    """
+    episode_path = Path(episode_path)
+    graph_path = episode_path / "graph.dot"
+
+    if not graph_path.exists():
+        raise FileNotFoundError(f"No graph.dot in {episode_path}")
+
+    # Load the episode graph
+    graph = load_dot(graph_path)
+
+    # Get action names from history
+    actions = parse_actions_from_history(episode_path)
+
+    # Get all card IDs and state count
+    card_ids = get_all_card_ids(graph)
+    max_state = get_max_state_index(graph)
+    num_states = max_state + 1
+
+    # Pad actions if needed
+    while len(actions) < num_states:
+        actions.append("unknown")
+
+    # Create trajectories directory
+    traj_dir = episode_path / "trajectories"
+    traj_dir.mkdir(exist_ok=True)
+
+    # Write game.jsonl (global state per action)
+    with open(traj_dir / "game.jsonl", "w") as f:
+        for state_idx in range(num_states):
+            game_state = extract_game_state(graph, state_idx)
+            record = {"action": actions[state_idx], "state": state_idx, **game_state}
+            f.write(json.dumps(record) + "\n")
+
+    # Build trajectory for each card
+    for card_id in sorted(card_ids):
+        traj_file = traj_dir / f"{card_id}.jsonl"
+
+        with open(traj_file, "w") as f:
+            prev_exists = False
+            prev_state = None
+
+            for state_idx in range(num_states):
+                node_state = extract_node_state(graph, card_id, state_idx)
+                edges = extract_node_edges(graph, card_id, state_idx)
+
+                # Card "exists" only when in hand or play
+                zone = node_state.get("zone") if node_state else None
+                exists = zone in ("hand", "play")
+
+                # Build current state dict for comparison
+                curr_state = None
+                if exists and node_state:
+                    curr_state = {
+                        "zone": zone,
+                        "exerted": node_state.get("exerted"),
+                        "damage": node_state.get("damage"),
+                    }
+
+                # Determine role
+                role = determine_role(actions[state_idx], card_id, prev_state, curr_state)
+
+                # Write line if card exists OR if it just died (was existing, now isn't)
+                if exists:
+                    record = {
+                        "role": role,
+                        "action": actions[state_idx],
+                        "state": state_idx,
+                        "zone": zone,
+                        "exerted": node_state.get("exerted"),
+                        "damage": node_state.get("damage"),
+                        "edges": edges,
+                    }
+                    f.write(json.dumps(record) + "\n")
+                elif prev_exists:
+                    # Card just died - write final line showing what killed it
+                    role = determine_role(actions[state_idx], card_id, prev_state, None)
+                    record = {
+                        "role": role,
+                        "action": actions[state_idx],
+                        "state": state_idx,
+                        "zone": zone,  # "ink", "discard", or None
+                    }
+                    f.write(json.dumps(record) + "\n")
+
+                prev_exists = exists
+                prev_state = curr_state
+
+    print(f"Built {len(card_ids)} card trajectories + game.jsonl ({num_states} states)")
+    print(f"  {traj_dir}/")
+
+    return traj_dir
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python bin/build-trajectories.py <episode_path>")
+        print("Example: python bin/build-trajectories.py output/episodes/abc.episode")
+        sys.exit(1)
+
+    episode_path = Path(sys.argv[1])
+
+    if not episode_path.exists():
+        print(f"Error: {episode_path} does not exist")
+        sys.exit(1)
+
+    build_trajectories(episode_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/trajectory-story.py
+++ b/bin/trajectory-story.py
@@ -1,0 +1,717 @@
+#!/usr/bin/env python3
+"""
+Generate a narrative story from a card's trajectory.
+
+Reads the trajectory JSONL and game.jsonl to produce a human-readable
+story from the card's perspective, focusing on meaningful moments.
+
+Usage:
+    python bin/trajectory-story.py <episode_path> <card_id>
+    python bin/trajectory-story.py output/episodes/abc.episode p1.aladdin_prince_ali.d
+    python bin/trajectory-story.py --narrative <episode_path> <card_id>
+"""
+import sys
+import json
+from pathlib import Path
+
+
+def load_jsonl(path: Path) -> list[dict]:
+    """Load a JSONL file into a list of dicts."""
+    records = []
+    with open(path) as f:
+        for line in f:
+            if line.strip():
+                records.append(json.loads(line))
+    return records
+
+
+def load_result(episode_path: Path) -> dict:
+    """Load result.json for game outcome."""
+    result_path = episode_path / "result.json"
+    if result_path.exists():
+        with open(result_path) as f:
+            return json.load(f)
+    return {}
+
+
+def load_game_states(episode_path: Path) -> dict[int, dict]:
+    """Load game.jsonl indexed by state number."""
+    game_path = episode_path / "trajectories" / "game.jsonl"
+    records = load_jsonl(game_path)
+    return {r["state"]: r for r in records}
+
+
+def get_lore_delta(prev_game: dict, curr_game: dict, player: str) -> int | None:
+    """Get lore change for a player between two game states."""
+    if not prev_game or not curr_game:
+        return None
+    prev_lore = int(prev_game.get(f"{player}_lore", 0))
+    curr_lore = int(curr_game.get(f"{player}_lore", 0))
+    delta = curr_lore - prev_lore
+    return delta if delta != 0 else None
+
+
+def load_trajectory(episode_path: Path, card_id: str) -> list[dict]:
+    """Load a card's trajectory."""
+    traj_path = episode_path / "trajectories" / f"{card_id}.jsonl"
+    if not traj_path.exists():
+        raise FileNotFoundError(f"No trajectory for {card_id}")
+    return load_jsonl(traj_path)
+
+
+def edges_changed(prev_edges: list, curr_edges: list) -> tuple[list, list]:
+    """Return (gained, lost) edges."""
+    prev_set = set(prev_edges or [])
+    curr_set = set(curr_edges or [])
+    gained = sorted(curr_set - prev_set)
+    lost = sorted(prev_set - curr_set)
+    return gained, lost
+
+
+def infer_actor_owner(action: str) -> str | None:
+    """Infer which player is acting from the action string."""
+    actor = extract_actor(action)
+    if actor and actor.startswith("p1"):
+        return "p1"
+    elif actor and actor.startswith("p2"):
+        return "p2"
+    return None
+
+
+def is_my_turn(game_state: dict, card_id: str, action: str) -> bool:
+    """Check if it's this card's owner's turn."""
+    owner = card_id.split(".")[0]  # p1 or p2
+    current = game_state.get("current_player")
+    if current:
+        return current == owner
+    # Fallback: infer from action
+    actor_owner = infer_actor_owner(action)
+    return actor_owner == owner
+
+
+def format_edges(edges: list) -> str:
+    """Format edge list for display."""
+    if not edges:
+        return ""
+    return ", ".join(e.replace("can_", "") for e in edges)
+
+
+def get_action_type(action: str) -> str:
+    """Extract action type from action string."""
+    if ":" in action:
+        return action.split(":")[0]
+    return action
+
+
+def extract_actor(action: str) -> str | None:
+    """Extract who did the action."""
+    if action in ("initial", "end", "unknown"):
+        return None
+    if "->" in action:
+        # challenge:p1.card->p2.target
+        actor_part = action.split("->")[0]
+        if ":" in actor_part:
+            return actor_part.split(":", 1)[1]
+    elif ":" in action:
+        return action.split(":", 1)[1]
+    return None
+
+
+def generate_story(episode_path: Path, card_id: str) -> str:
+    """Generate narrative story for a card."""
+    game_states = load_game_states(episode_path)
+    trajectory = load_trajectory(episode_path, card_id)
+    result = load_result(episode_path)
+
+    owner = card_id.split(".")[0]
+    opponent = "p2" if owner == "p1" else "p1"
+
+    lines = []
+    lines.append(f"{card_id}")
+    lines.append("=" * len(card_id))
+    lines.append("")
+
+    current_turn = None
+    prev_edges = []
+    prev_game = {}
+    noise_count = 0
+
+    for i, record in enumerate(trajectory):
+        state_idx = record["state"]
+        game = game_states.get(state_idx, {})
+        role = record.get("role", "observer")
+        action = record.get("action", "")
+        zone = record.get("zone")
+        edges = record.get("edges", [])
+        exerted = record.get("exerted")
+        damage = record.get("damage")
+
+        turn = game.get("turn", "?")
+        p1_lore = game.get("p1_lore", "0")
+        p2_lore = game.get("p2_lore", "0")
+        current_player = game.get("current_player")
+        my_turn = is_my_turn(game, card_id, action)
+
+        # Turn header
+        if turn != current_turn:
+            if noise_count > 0:
+                lines.append(f"    ... ({noise_count} actions)")
+                noise_count = 0
+            lines.append("")
+            turn_marker = f"Turn {turn}"
+            player_marker = f"({current_player})" if current_player else ""
+            lore_marker = f"{owner}:{p1_lore if owner == 'p1' else p2_lore} | {opponent}:{p2_lore if owner == 'p1' else p1_lore}"
+            lines.append(f"═══ {turn_marker} {player_marker} ═══ {lore_marker}")
+            current_turn = turn
+
+        # Check edge changes
+        gained, lost = edges_changed(prev_edges, edges)
+
+        # Determine if this line is signal or noise
+        is_signal = False
+        line_parts = []
+
+        if role == "actor":
+            is_signal = True
+            action_type = get_action_type(action).upper()
+            if action_type == "PLAY":
+                line_parts.append(f"[{state_idx}] >>> PLAYED <<<")
+                line_parts.append(f"      zone: {zone}")
+            elif action_type == "QUEST":
+                line_parts.append(f"[{state_idx}] >>> QUESTED <<<")
+                line_parts.append(f"      exerted")
+                lore_delta = get_lore_delta(prev_game, game, owner)
+                if lore_delta:
+                    prev_lore = int(prev_game.get(f"{owner}_lore", 0))
+                    curr_lore = int(game.get(f"{owner}_lore", 0))
+                    line_parts.append(f"      {owner} lore: {prev_lore} → {curr_lore} (+{lore_delta})")
+            elif action_type == "INK":
+                line_parts.append(f"[{state_idx}] >>> INKED (removed from game) <<<")
+            elif action_type == "CHALLENGE":
+                target = action.split("->")[1] if "->" in action else "?"
+                line_parts.append(f"[{state_idx}] >>> CHALLENGED {target} <<<")
+            else:
+                line_parts.append(f"[{state_idx}] >>> {action_type} <<<")
+
+        elif role == "target":
+            is_signal = True
+            action_type = get_action_type(action).upper()
+            actor = extract_actor(action)
+            if action_type == "CHALLENGE":
+                line_parts.append(f"[{state_idx}] !!! CHALLENGED by {actor} !!!")
+                if zone == "discard":
+                    line_parts.append(f"      → BANISHED")
+                elif damage and damage != "0":
+                    line_parts.append(f"      damage: {damage}")
+            else:
+                line_parts.append(f"[{state_idx}] !!! TARGETED by {action} !!!")
+
+        elif role == "byproduct":
+            is_signal = True
+            if action == "initial":
+                line_parts.append(f"[{state_idx}] Drawn into hand")
+            elif zone == "ink":
+                # This shouldn't happen - ink should be actor
+                line_parts.append(f"[{state_idx}] Moved to ink")
+            elif zone == "discard":
+                line_parts.append(f"[{state_idx}] Banished")
+            elif zone is None:
+                line_parts.append(f"[{state_idx}] Removed from game")
+            elif exerted == "0" and i > 0 and trajectory[i-1].get("exerted") == "1":
+                line_parts.append(f"[{state_idx}] Readied")
+            else:
+                line_parts.append(f"[{state_idx}] State changed: zone={zone}")
+
+        elif role == "observer":
+            # Check if this is a meaningful decision point
+            action_type = get_action_type(action)
+            actor = extract_actor(action)
+
+            # Did they choose something else when I had the same option?
+            # Only show if it changed my edges (gained or lost something)
+            if my_turn and action_type in ("play", "ink", "quest", "challenge"):
+                can_key = f"can_{action_type}"
+                my_could = can_key in prev_edges
+                if my_could and actor and card_id not in action and (gained or lost):
+                    is_signal = True
+                    line_parts.append(f"[{state_idx}] {owner} chose to {action_type} {actor}")
+                    remaining = [e for e in prev_edges if e != can_key]
+                    if remaining:
+                        line_parts.append(f"      I could still: {format_edges(remaining)}")
+
+        # Edge changes are signal, but format nicely
+        if gained and zone in ("hand", "play"):
+            is_signal = True
+            if not line_parts:
+                # Show what action caused this edge change
+                action_type = get_action_type(action)
+                if action_type == "end":
+                    line_parts.append(f"[{state_idx}] (turn ended)")
+                else:
+                    line_parts.append(f"[{state_idx}] (after {action_type})")
+            line_parts.append(f"      +++ gained: {format_edges(gained)}")
+
+        if lost and zone in ("hand", "play") and role not in ("actor", "target"):
+            # Don't show "lost" for actor/target - it's implicit
+            is_signal = True
+            if not line_parts:
+                action_type = get_action_type(action)
+                if action_type == "end":
+                    line_parts.append(f"[{state_idx}] (turn ended)")
+                else:
+                    line_parts.append(f"[{state_idx}] (after {action_type})")
+            line_parts.append(f"      --- lost: {format_edges(lost)}")
+
+        # Output or count noise
+        if is_signal:
+            if noise_count > 0:
+                lines.append(f"    ... ({noise_count} actions)")
+                noise_count = 0
+            for part in line_parts:
+                lines.append(part)
+        else:
+            noise_count += 1
+
+        prev_edges = edges
+        prev_game = game
+
+    # Final noise
+    if noise_count > 0:
+        lines.append(f"    ... ({noise_count} actions)")
+
+    # Game outcome
+    if result:
+        lines.append("")
+        lines.append("═══ GAME RESULT ═══")
+        winner = result.get("winner", "?")
+        final_lore = result.get("final_lore", {})
+        p1_final = final_lore.get("p1", "?")
+        p2_final = final_lore.get("p2", "?")
+        total_turns = result.get("total_turns", "?")
+
+        outcome = "WIN" if winner == owner else "LOSS"
+        lines.append(f"  {outcome}: {winner} wins")
+        lines.append(f"  Final: p1={p1_final}, p2={p2_final}")
+        lines.append(f"  Turns: {total_turns}")
+
+    return "\n".join(lines)
+
+
+def format_card_name(card_id: str) -> str:
+    """Convert card_id to readable name: p1.mulan_free_spirit.b -> Mulan, Free Spirit"""
+    parts = card_id.split(".")
+    if len(parts) >= 2:
+        name_part = parts[1]  # mulan_free_spirit or robin_hood_beloved_outlaw
+        # Convert underscores to spaces and title case
+        words = name_part.replace("_", " ").title()
+        return words
+    return card_id
+
+
+def format_other_card(card_id: str) -> str:
+    """Format another card's name for narrative."""
+    return format_card_name(card_id)
+
+
+def edge_to_verb(edge: str) -> str:
+    """Convert edge to verb phrase."""
+    mapping = {
+        "can_play": "be played",
+        "can_ink": "be inked",
+        "can_quest": "quest",
+        "can_challenge": "challenge",
+    }
+    return mapping.get(edge, edge.replace("can_", ""))
+
+
+def edge_to_noun(edge: str) -> str:
+    """Convert edge to noun phrase for abilities."""
+    mapping = {
+        "can_play": "play",
+        "can_ink": "ink",
+        "can_quest": "quest",
+        "can_challenge": "challenge",
+    }
+    return mapping.get(edge, edge.replace("can_", ""))
+
+
+def generate_narrative(episode_path: Path, card_id: str) -> str:
+    """Generate prose narrative for a card's trajectory."""
+    game_states = load_game_states(episode_path)
+    trajectory = load_trajectory(episode_path, card_id)
+    result = load_result(episode_path)
+
+    owner = card_id.split(".")[0]
+    owner_name = "my owner" if owner == "p1" else "my owner"
+    opponent = "p2" if owner == "p1" else "p1"
+    card_name = format_card_name(card_id)
+
+    # Collect events by turn for grouping
+    events_by_turn = {}  # turn -> list of event dicts
+
+    # Stats for arc summary
+    stats = {
+        "turns_in_hand": 0,
+        "turns_in_play": 0,
+        "quests": 0,
+        "challenges_made": 0,
+        "challenges_received": 0,
+        "damage_taken": 0,
+        "final_state": "unknown",
+        "play_turn": None,
+        "death_turn": None,
+        "lore_contributed": 0,
+    }
+
+    prev_edges = []
+    prev_turn = None
+    prev_zone = None
+    prev_game = {}
+
+    for i, record in enumerate(trajectory):
+        state_idx = record["state"]
+        game = game_states.get(state_idx, {})
+        role = record.get("role", "observer")
+        action = record.get("action", "")
+        zone = record.get("zone")
+        edges = record.get("edges", [])
+        exerted = record.get("exerted")
+        damage = record.get("damage")
+
+        turn = int(game.get("turn", 0))
+        my_turn = is_my_turn(game, card_id, action)
+        action_type = get_action_type(action)
+
+        # Calculate lore delta
+        lore_delta = get_lore_delta(prev_game, game, owner)
+
+        if turn not in events_by_turn:
+            events_by_turn[turn] = []
+
+        # Track zone time
+        if zone == "hand" and prev_zone != "hand":
+            pass  # entering hand
+        if zone == "play" and prev_zone != "play":
+            stats["play_turn"] = turn
+
+        # Check edge changes
+        gained, lost = edges_changed(prev_edges, edges)
+
+        event = {
+            "state": state_idx,
+            "role": role,
+            "action": action,
+            "action_type": action_type,
+            "zone": zone,
+            "edges": edges,
+            "gained": gained,
+            "lost": lost,
+            "exerted": exerted,
+            "damage": damage,
+            "my_turn": my_turn,
+            "turn": turn,
+            "prev_edges": prev_edges.copy(),
+            "lore_delta": lore_delta,
+            "prev_lore": int(prev_game.get(f"{owner}_lore", 0)) if prev_game else 0,
+            "curr_lore": int(game.get(f"{owner}_lore", 0)),
+        }
+
+        # Classify event type
+        if role == "actor":
+            if action_type == "play":
+                event["narrative_type"] = "played"
+            elif action_type == "quest":
+                event["narrative_type"] = "quested"
+                stats["quests"] += 1
+            elif action_type == "ink":
+                event["narrative_type"] = "inked"
+                stats["final_state"] = "inked"
+                stats["death_turn"] = turn
+            elif action_type == "challenge":
+                event["narrative_type"] = "challenged"
+                stats["challenges_made"] += 1
+            else:
+                event["narrative_type"] = "acted"
+
+        elif role == "target":
+            if action_type == "challenge":
+                stats["challenges_received"] += 1
+                if zone == "discard":
+                    event["narrative_type"] = "banished"
+                    stats["final_state"] = "banished"
+                    stats["death_turn"] = turn
+                    if damage:
+                        stats["damage_taken"] = int(damage) if damage.isdigit() else 0
+                else:
+                    event["narrative_type"] = "damaged"
+                    if damage:
+                        stats["damage_taken"] = int(damage) if damage.isdigit() else 0
+            else:
+                event["narrative_type"] = "targeted"
+
+        elif role == "byproduct":
+            if action == "initial":
+                event["narrative_type"] = "drawn"
+            elif exerted == "0" and i > 0 and trajectory[i-1].get("exerted") == "1":
+                event["narrative_type"] = "readied"
+            elif zone == "discard":
+                event["narrative_type"] = "banished"
+                stats["final_state"] = "banished"
+                stats["death_turn"] = turn
+            elif zone is None:
+                event["narrative_type"] = "removed"
+            else:
+                event["narrative_type"] = "changed"
+
+        elif role == "observer":
+            # Decision point check - only signal if it changed my edges
+            if my_turn and action_type in ("play", "ink", "quest", "challenge"):
+                can_key = f"can_{action_type}"
+                actor = extract_actor(action)
+                # Only show "passed over" if I lost an edge as a result
+                if can_key in prev_edges and actor and card_id not in action and (gained or lost):
+                    event["narrative_type"] = "passed_over"
+                    event["chosen_card"] = actor
+                    event["chosen_action"] = action_type
+                else:
+                    event["narrative_type"] = "observed"
+            else:
+                event["narrative_type"] = "observed"
+
+        # Track edge changes as separate events if significant
+        if gained and zone in ("hand", "play") and event.get("narrative_type") == "observed":
+            event["narrative_type"] = "gained_ability"
+        if lost and zone in ("hand", "play") and event.get("narrative_type") not in ("played", "quested", "inked", "challenged", "passed_over"):
+            if event.get("narrative_type") == "observed":
+                event["narrative_type"] = "lost_ability"
+
+        events_by_turn[turn].append(event)
+        prev_edges = edges
+        prev_turn = turn
+        prev_zone = zone
+        prev_game = game
+
+    # Count turns in each zone
+    turns_seen = set()
+    for turn, events in events_by_turn.items():
+        for e in events:
+            if e["zone"] == "hand":
+                turns_seen.add(("hand", turn))
+            elif e["zone"] == "play":
+                turns_seen.add(("play", turn))
+
+    stats["turns_in_hand"] = len([t for z, t in turns_seen if z == "hand"])
+    stats["turns_in_play"] = len([t for z, t in turns_seen if z == "play"])
+
+    # If card survived to end
+    if stats["final_state"] == "unknown":
+        last_event = trajectory[-1] if trajectory else {}
+        if last_event.get("zone") == "play":
+            stats["final_state"] = "survived"
+        elif last_event.get("zone") == "hand":
+            stats["final_state"] = "never_played"
+
+    # Now generate prose
+    lines = []
+    lines.append(f"**{card_name}** — Narrative")
+    lines.append("")
+
+    sorted_turns = sorted(events_by_turn.keys())
+
+    # Group consecutive quiet turns
+    i = 0
+    while i < len(sorted_turns):
+        turn = sorted_turns[i]
+        events = events_by_turn[turn]
+
+        # Check if this turn has any significant events
+        significant = [e for e in events if e.get("narrative_type") not in ("observed", None)]
+
+        if not significant:
+            # Find consecutive quiet turns
+            quiet_start = turn
+            quiet_end = turn
+            j = i + 1
+            while j < len(sorted_turns):
+                next_turn = sorted_turns[j]
+                next_events = events_by_turn[next_turn]
+                next_significant = [e for e in next_events if e.get("narrative_type") not in ("observed", None)]
+                if not next_significant:
+                    quiet_end = next_turn
+                    j += 1
+                else:
+                    break
+
+            # Summarize quiet period
+            zone = events[0].get("zone", "hand") if events else "hand"
+            if quiet_start == quiet_end:
+                lines.append(f"**Turn {quiet_start}:** I waited in {zone}.")
+            else:
+                lines.append(f"**Turns {quiet_start}-{quiet_end}:** I waited in {zone} while the game developed.")
+            lines.append("")
+            i = j
+            continue
+
+        # Process turn with significant events
+        turn_lines = []
+        turn_lines.append(f"**Turn {turn}:**")
+
+        for event in events:
+            narrative_type = event.get("narrative_type")
+
+            if narrative_type == "drawn":
+                turn_lines.append("I was drawn into hand.")
+
+            elif narrative_type == "played":
+                turn_lines.append("I was played onto the board.")
+
+            elif narrative_type == "quested":
+                lore_delta = event.get("lore_delta")
+                if lore_delta:
+                    prev_lore = event.get("prev_lore", 0)
+                    curr_lore = event.get("curr_lore", 0)
+                    turn_lines.append(f"I quested, becoming exerted. ({owner} lore: {prev_lore} → {curr_lore})")
+                else:
+                    turn_lines.append("I quested, becoming exerted.")
+
+            elif narrative_type == "inked":
+                turn_lines.append("I was inked, leaving the game permanently.")
+
+            elif narrative_type == "challenged":
+                target = event["action"].split("->")[1] if "->" in event["action"] else "an opponent"
+                target_name = format_other_card(target)
+                turn_lines.append(f"I challenged {target_name}.")
+
+            elif narrative_type == "banished":
+                actor = extract_actor(event["action"])
+                if actor:
+                    actor_name = format_other_card(actor)
+                    turn_lines.append(f"I was challenged by {actor_name} and banished.")
+                else:
+                    turn_lines.append("I was banished.")
+
+            elif narrative_type == "damaged":
+                actor = extract_actor(event["action"])
+                damage = event.get("damage", "?")
+                if actor:
+                    actor_name = format_other_card(actor)
+                    turn_lines.append(f"I was challenged by {actor_name}, taking {damage} damage.")
+                else:
+                    turn_lines.append(f"I took {damage} damage.")
+
+            elif narrative_type == "targeted":
+                turn_lines.append(f"I was targeted by {event['action']}.")
+
+            elif narrative_type == "readied":
+                turn_lines.append("I readied at the start of the turn.")
+
+            elif narrative_type == "passed_over":
+                chosen = event.get("chosen_card", "another card")
+                chosen_name = format_other_card(chosen)
+                action = event.get("chosen_action", "use")
+                remaining = [e for e in event.get("prev_edges", []) if e != f"can_{action}"]
+
+                if remaining:
+                    abilities = ", ".join(edge_to_noun(e) for e in remaining)
+                    turn_lines.append(f"My owner chose to {action} {chosen_name} instead of me (I could still {abilities}).")
+                else:
+                    turn_lines.append(f"My owner chose to {action} {chosen_name} instead of me.")
+
+            elif narrative_type == "gained_ability":
+                gained = event.get("gained", [])
+                if gained:
+                    abilities = ", ".join(edge_to_noun(e) for e in gained)
+                    turn_lines.append(f"I gained the ability to {abilities}.")
+
+            elif narrative_type == "lost_ability":
+                lost = event.get("lost", [])
+                if lost:
+                    abilities = ", ".join(edge_to_noun(e) for e in lost)
+                    turn_lines.append(f"I lost my chance to {abilities}.")
+
+            # Skip observed events with no significance
+            elif narrative_type in ("observed", None):
+                pass
+
+        lines.append(" ".join(turn_lines))
+        lines.append("")
+        i += 1
+
+    # Arc summary
+    lines.append("---")
+    lines.append("")
+    lines.append("**Arc:**")
+
+    arc_parts = []
+    if stats["turns_in_hand"] > 0:
+        arc_parts.append(f"Held in hand for {stats['turns_in_hand']} turn(s)")
+    if stats["play_turn"]:
+        arc_parts.append(f"Played on turn {stats['play_turn']}")
+    if stats["turns_in_play"] > 0:
+        arc_parts.append(f"{stats['turns_in_play']} turn(s) in play")
+    if stats["quests"] > 0:
+        arc_parts.append(f"{stats['quests']} quest(s)")
+    if stats["challenges_made"] > 0:
+        arc_parts.append(f"{stats['challenges_made']} challenge(s) made")
+    if stats["challenges_received"] > 0:
+        arc_parts.append(f"challenged {stats['challenges_received']} time(s)")
+    if stats["damage_taken"] > 0:
+        arc_parts.append(f"{stats['damage_taken']} damage taken")
+
+    # Final state
+    if stats["final_state"] == "banished":
+        arc_parts.append(f"banished on turn {stats['death_turn']}")
+    elif stats["final_state"] == "inked":
+        arc_parts.append(f"inked on turn {stats['death_turn']}")
+    elif stats["final_state"] == "survived":
+        arc_parts.append("survived to end")
+    elif stats["final_state"] == "never_played":
+        arc_parts.append("never played")
+
+    lines.append(" → ".join(arc_parts))
+
+    # Game outcome
+    if result:
+        lines.append("")
+        winner = result.get("winner", "?")
+        final_lore = result.get("final_lore", {})
+        p1_final = final_lore.get("p1", "?")
+        p2_final = final_lore.get("p2", "?")
+
+        outcome = "won" if winner == owner else "lost"
+        lines.append(f"**Game Result:** We {outcome}. Final score: p1={p1_final}, p2={p2_final}. Winner: {winner}.")
+
+    return "\n".join(lines)
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Generate narrative story from a card's trajectory"
+    )
+    parser.add_argument("episode_path", help="Path to the episode directory")
+    parser.add_argument("card_id", help="Card ID (e.g., p1.mulan_free_spirit.b)")
+    parser.add_argument(
+        "--narrative", "-n",
+        action="store_true",
+        help="Output prose narrative instead of structured format"
+    )
+
+    args = parser.parse_args()
+    episode_path = Path(args.episode_path)
+
+    if not episode_path.exists():
+        print(f"Error: {episode_path} does not exist")
+        sys.exit(1)
+
+    if args.narrative:
+        story = generate_narrative(episode_path, args.card_id)
+    else:
+        story = generate_story(episode_path, args.card_id)
+
+    print(story)
+
+
+if __name__ == "__main__":
+    main()

--- a/justfile
+++ b/justfile
@@ -53,3 +53,13 @@ generate-games num_seeds="1" games_per_seed="1" *flags="":
     echo "Episodes: $(ls -1d output/episodes/*.episode 2>/dev/null | wc -l)"
     du -sh output/ 2>/dev/null || true
 
+# Extract per-card trajectory files from an episode
+# Usage: just build-trajectories output/episodes/abc.episode
+build-trajectories episode_path:
+    {{python}} bin/build-trajectories.py "{{episode_path}}"
+
+# Build narrative files for all cards across episodes
+# Usage: just build-narratives                     (all episodes)
+#        just build-narratives output/episodes/abc.episode  (single episode)
+build-narratives *episode_path:
+    {{python}} bin/build-narratives.py {{episode_path}}

--- a/output.example/example-narratives/heathcliff_stoic_butler/0xuebtpz-1.p1.c.txt
+++ b/output.example/example-narratives/heathcliff_stoic_butler/0xuebtpz-1.p1.c.txt
@@ -1,0 +1,18 @@
+**Heathcliff Stoic Butler** — Narrative
+
+**Turn 0:** I was drawn into hand. My owner chose to ink Lena Sabrewing Rebellious Teenager instead of me.
+
+**Turn 1:** I waited in hand.
+
+**Turn 2:** I gained the ability to ink. My owner chose to ink Maleficent Sorceress instead of me.
+
+**Turn 3:** I waited in hand.
+
+**Turn 4:** I gained the ability to ink. I was inked, leaving the game permanently.
+
+---
+
+**Arc:**
+Held in hand for 5 turn(s) → inked on turn 4
+
+**Game Result:** We lost. Final score: p1=6, p2=20. Winner: p2.

--- a/output.example/example-narratives/heathcliff_stoic_butler/0xuebtpz-1.p1.d.txt
+++ b/output.example/example-narratives/heathcliff_stoic_butler/0xuebtpz-1.p1.d.txt
@@ -1,0 +1,14 @@
+**Heathcliff Stoic Butler** — Narrative
+
+**Turn 8:** My owner chose to play Luisa Madrigal Magically Strong One instead of me (I could still ink). My owner chose to ink Winnie The Pooh Hunny Wizard instead of me.
+
+**Turn 9:** I waited in hand.
+
+**Turn 10:** I gained the ability to ink, play. I was inked, leaving the game permanently.
+
+---
+
+**Arc:**
+Held in hand for 3 turn(s) → inked on turn 10
+
+**Game Result:** We lost. Final score: p1=6, p2=20. Winner: p2.

--- a/output.example/example-narratives/heathcliff_stoic_butler/0xuebtpz-10.p1.c.txt
+++ b/output.example/example-narratives/heathcliff_stoic_butler/0xuebtpz-10.p1.c.txt
@@ -1,0 +1,26 @@
+**Heathcliff Stoic Butler** — Narrative
+
+**Turn 0:** I was drawn into hand. My owner chose to ink Maleficent Sorceress instead of me.
+
+**Turn 1:** I waited in hand.
+
+**Turn 2:** I gained the ability to ink. My owner chose to ink Lena Sabrewing Rebellious Teenager instead of me.
+
+**Turn 3:** I waited in hand.
+
+**Turn 4:** I gained the ability to ink. My owner chose to ink Tinker Bell Fast Flier instead of me.
+
+**Turn 5:** I waited in hand.
+
+**Turn 6:** I gained the ability to ink. My owner chose to ink Winnie The Pooh Hunny Wizard instead of me.
+
+**Turn 7:** I waited in hand.
+
+**Turn 8:** I gained the ability to ink, play. My owner chose to play Luisa Madrigal Magically Strong One instead of me (I could still ink). I was inked, leaving the game permanently.
+
+---
+
+**Arc:**
+Held in hand for 9 turn(s) → inked on turn 8
+
+**Game Result:** We won. Final score: p1=20, p2=3. Winner: p1.

--- a/output.example/example-narratives/heathcliff_stoic_butler/0xuebtpz-10.p1.d.txt
+++ b/output.example/example-narratives/heathcliff_stoic_butler/0xuebtpz-10.p1.d.txt
@@ -1,0 +1,26 @@
+**Heathcliff Stoic Butler** — Narrative
+
+**Turn 8:** My owner chose to play Luisa Madrigal Magically Strong One instead of me (I could still ink). My owner chose to ink Heathcliff Stoic Butler instead of me.
+
+**Turn 9:** I waited in hand.
+
+**Turn 10:** I gained the ability to ink, play. I was played onto the board.
+
+**Turn 11:** I waited in play.
+
+**Turn 12:** I gained the ability to challenge, quest. I quested, becoming exerted. (p1 lore: 9 → 11)
+
+**Turn 13:** I waited in play.
+
+**Turn 14:** I readied at the start of the turn. I quested, becoming exerted. (p1 lore: 15 → 17)
+
+**Turn 15:** I waited in play.
+
+**Turn 16:** I readied at the start of the turn. I quested, becoming exerted. (p1 lore: 17 → 19)
+
+---
+
+**Arc:**
+Held in hand for 3 turn(s) → Played on turn 10 → 7 turn(s) in play → 3 quest(s) → survived to end
+
+**Game Result:** We won. Final score: p1=20, p2=3. Winner: p1.

--- a/output.example/example-narratives/heathcliff_stoic_butler/0xuebtpz-11.p1.c.txt
+++ b/output.example/example-narratives/heathcliff_stoic_butler/0xuebtpz-11.p1.c.txt
@@ -1,0 +1,26 @@
+**Heathcliff Stoic Butler** — Narrative
+
+**Turn 0:** I was drawn into hand. My owner chose to ink Fred Mascot By Day instead of me.
+
+**Turn 1:** I waited in hand.
+
+**Turn 2:** I gained the ability to ink. My owner chose to ink Maleficent Sorceress instead of me.
+
+**Turn 3:** I waited in hand.
+
+**Turn 4:** I gained the ability to ink. My owner chose to ink Aladdin Prince Ali instead of me.
+
+**Turn 5:** I waited in hand.
+
+**Turn 6:** I gained the ability to ink. My owner chose to ink Winnie The Pooh Hunny Wizard instead of me.
+
+**Turn 7:** I waited in hand.
+
+**Turn 8:** I gained the ability to ink, play. My owner chose to play Heathcliff Stoic Butler instead of me (I could still ink). I was inked, leaving the game permanently.
+
+---
+
+**Arc:**
+Held in hand for 9 turn(s) → inked on turn 8
+
+**Game Result:** We won. Final score: p1=21, p2=7. Winner: p1.

--- a/output.example/example-narratives/heathcliff_stoic_butler/0xuebtpz-11.p1.d.txt
+++ b/output.example/example-narratives/heathcliff_stoic_butler/0xuebtpz-11.p1.d.txt
@@ -1,0 +1,14 @@
+**Heathcliff Stoic Butler** — Narrative
+
+**Turn 8:** I was played onto the board.
+
+**Turn 9:** I waited in play.
+
+**Turn 10:** I gained the ability to challenge, quest. I challenged Jafar Royal Vizier.
+
+---
+
+**Arc:**
+Held in hand for 1 turn(s) → Played on turn 8 → 3 turn(s) in play → 1 challenge(s) made
+
+**Game Result:** We won. Final score: p1=21, p2=7. Winner: p1.

--- a/output.example/example-narratives/heathcliff_stoic_butler/0xuebtpz-12.p1.c.txt
+++ b/output.example/example-narratives/heathcliff_stoic_butler/0xuebtpz-12.p1.c.txt
@@ -1,0 +1,22 @@
+**Heathcliff Stoic Butler** — Narrative
+
+**Turn 0:** I was drawn into hand. My owner chose to ink Lena Sabrewing Rebellious Teenager instead of me.
+
+**Turn 1:** I waited in hand.
+
+**Turn 2:** I gained the ability to ink. My owner chose to ink Winnie The Pooh Hunny Wizard instead of me.
+
+**Turn 3:** I waited in hand.
+
+**Turn 4:** I gained the ability to ink. My owner chose to ink Tinker Bell Fast Flier instead of me.
+
+**Turn 5:** I waited in hand.
+
+**Turn 6:** I gained the ability to ink. I was inked, leaving the game permanently.
+
+---
+
+**Arc:**
+Held in hand for 7 turn(s) → inked on turn 6
+
+**Game Result:** We won. Final score: p1=20, p2=8. Winner: p1.

--- a/output.example/example-narratives/heathcliff_stoic_butler/0xuebtpz-12.p1.d.txt
+++ b/output.example/example-narratives/heathcliff_stoic_butler/0xuebtpz-12.p1.d.txt
@@ -1,0 +1,18 @@
+**Heathcliff Stoic Butler** — Narrative
+
+**Turn 8:** My owner chose to ink Maleficent Sorceress instead of me (I could still play). I was played onto the board.
+
+**Turn 9:** I waited in play.
+
+**Turn 10:** I gained the ability to challenge, quest. I challenged Dumptruck Karnage'S Second Mate.
+
+**Turn 11:** I was challenged by Robin Hood Beloved Outlaw, taking 2 damage.
+
+**Turn 12:** I readied at the start of the turn. I challenged Aladdin Cornered Swordsman.
+
+---
+
+**Arc:**
+Held in hand for 1 turn(s) → Played on turn 8 → 5 turn(s) in play → 2 challenge(s) made → challenged 1 time(s) → 2 damage taken
+
+**Game Result:** We won. Final score: p1=20, p2=8. Winner: p1.

--- a/output.example/example-narratives/heathcliff_stoic_butler/0xuebtpz-13.p1.c.txt
+++ b/output.example/example-narratives/heathcliff_stoic_butler/0xuebtpz-13.p1.c.txt
@@ -1,0 +1,22 @@
+**Heathcliff Stoic Butler** — Narrative
+
+**Turn 0:** I was drawn into hand. My owner chose to ink Maleficent Sorceress instead of me.
+
+**Turn 1:** I waited in hand.
+
+**Turn 2:** I gained the ability to ink. My owner chose to ink Winnie The Pooh Hunny Wizard instead of me.
+
+**Turn 3:** I waited in hand.
+
+**Turn 4:** I gained the ability to ink. My owner chose to ink Aladdin Prince Ali instead of me.
+
+**Turn 5:** I waited in hand.
+
+**Turn 6:** I gained the ability to ink. I was inked, leaving the game permanently.
+
+---
+
+**Arc:**
+Held in hand for 7 turn(s) → inked on turn 6
+
+**Game Result:** We lost. Final score: p1=13, p2=20. Winner: p2.

--- a/output.example/example-narratives/heathcliff_stoic_butler/0xuebtpz-13.p1.d.txt
+++ b/output.example/example-narratives/heathcliff_stoic_butler/0xuebtpz-13.p1.d.txt
@@ -1,0 +1,10 @@
+**Heathcliff Stoic Butler** — Narrative
+
+**Turn 8:** I was inked, leaving the game permanently.
+
+---
+
+**Arc:**
+Held in hand for 1 turn(s) → inked on turn 8
+
+**Game Result:** We lost. Final score: p1=13, p2=20. Winner: p2.

--- a/output.example/example-narratives/heathcliff_stoic_butler/0xuebtpz-14.p1.c.txt
+++ b/output.example/example-narratives/heathcliff_stoic_butler/0xuebtpz-14.p1.c.txt
@@ -1,0 +1,10 @@
+**Heathcliff Stoic Butler** — Narrative
+
+**Turn 0:** I was drawn into hand. I was inked, leaving the game permanently.
+
+---
+
+**Arc:**
+Held in hand for 1 turn(s) → inked on turn 0
+
+**Game Result:** We won. Final score: p1=20, p2=17. Winner: p1.

--- a/output.example/example-narratives/heathcliff_stoic_butler/0xuebtpz-14.p1.d.txt
+++ b/output.example/example-narratives/heathcliff_stoic_butler/0xuebtpz-14.p1.d.txt
@@ -1,0 +1,16 @@
+**Heathcliff Stoic Butler** — Narrative
+
+**Turn 8:** My owner chose to ink The White Rose Jewel Of The Garden instead of me (I could still play). I was played onto the board.
+
+**Turn 9:** I waited in play.
+
+**Turn 10:** I gained the ability to challenge, quest. I challenged Robin Hood Beloved Outlaw.
+
+**Turn 11:** I was challenged by Prince Eric Dashing And Brave and banished.
+
+---
+
+**Arc:**
+Held in hand for 1 turn(s) → Played on turn 8 → 4 turn(s) in play → 1 challenge(s) made → challenged 1 time(s) → banished on turn 11
+
+**Game Result:** We won. Final score: p1=20, p2=17. Winner: p1.

--- a/output.example/example-narratives/heathcliff_stoic_butler/0xuebtpz-15.p1.c.txt
+++ b/output.example/example-narratives/heathcliff_stoic_butler/0xuebtpz-15.p1.c.txt
@@ -1,0 +1,22 @@
+**Heathcliff Stoic Butler** — Narrative
+
+**Turn 0:** I was drawn into hand. My owner chose to ink Lena Sabrewing Rebellious Teenager instead of me.
+
+**Turn 1:** I waited in hand.
+
+**Turn 2:** I gained the ability to ink. My owner chose to ink Aladdin Prince Ali instead of me.
+
+**Turn 3:** I waited in hand.
+
+**Turn 4:** I gained the ability to ink. My owner chose to ink Winnie The Pooh Hunny Wizard instead of me.
+
+**Turn 5:** I waited in hand.
+
+**Turn 6:** I gained the ability to ink. I was inked, leaving the game permanently.
+
+---
+
+**Arc:**
+Held in hand for 7 turn(s) → inked on turn 6
+
+**Game Result:** We lost. Final score: p1=7, p2=20. Winner: p2.

--- a/output.example/example-narratives/heathcliff_stoic_butler/0xuebtpz-15.p1.d.txt
+++ b/output.example/example-narratives/heathcliff_stoic_butler/0xuebtpz-15.p1.d.txt
@@ -1,0 +1,10 @@
+**Heathcliff Stoic Butler** — Narrative
+
+**Turn 8:** I was inked, leaving the game permanently.
+
+---
+
+**Arc:**
+Held in hand for 1 turn(s) → inked on turn 8
+
+**Game Result:** We lost. Final score: p1=7, p2=20. Winner: p2.

--- a/output.example/example-narratives/heathcliff_stoic_butler/0xuebtpz-16.p1.c.txt
+++ b/output.example/example-narratives/heathcliff_stoic_butler/0xuebtpz-16.p1.c.txt
@@ -1,0 +1,10 @@
+**Heathcliff Stoic Butler** — Narrative
+
+**Turn 0:** I was drawn into hand. I was inked, leaving the game permanently.
+
+---
+
+**Arc:**
+Held in hand for 1 turn(s) → inked on turn 0
+
+**Game Result:** We won. Final score: p1=20, p2=15. Winner: p1.

--- a/output.example/example-narratives/heathcliff_stoic_butler/0xuebtpz-16.p1.d.txt
+++ b/output.example/example-narratives/heathcliff_stoic_butler/0xuebtpz-16.p1.d.txt
@@ -1,0 +1,16 @@
+**Heathcliff Stoic Butler** — Narrative
+
+**Turn 8:** I was played onto the board.
+
+**Turn 9:** I waited in play.
+
+**Turn 10:** I gained the ability to challenge, quest. I challenged Stitch New Dog.
+
+**Turn 11:** I was challenged by Prince Eric Dashing And Brave and banished.
+
+---
+
+**Arc:**
+Held in hand for 1 turn(s) → Played on turn 8 → 4 turn(s) in play → 1 challenge(s) made → challenged 1 time(s) → banished on turn 11
+
+**Game Result:** We won. Final score: p1=20, p2=15. Winner: p1.

--- a/output.example/example-narratives/heathcliff_stoic_butler/0xuebtpz-17.p1.c.txt
+++ b/output.example/example-narratives/heathcliff_stoic_butler/0xuebtpz-17.p1.c.txt
@@ -1,0 +1,22 @@
+**Heathcliff Stoic Butler** — Narrative
+
+**Turn 0:** I was drawn into hand. My owner chose to ink Lena Sabrewing Rebellious Teenager instead of me.
+
+**Turn 1:** I waited in hand.
+
+**Turn 2:** I gained the ability to ink. My owner chose to ink Aladdin Prince Ali instead of me.
+
+**Turn 3:** I waited in hand.
+
+**Turn 4:** I gained the ability to ink. My owner chose to ink Maleficent Sorceress instead of me.
+
+**Turn 5:** I waited in hand.
+
+**Turn 6:** I gained the ability to ink. I was inked, leaving the game permanently.
+
+---
+
+**Arc:**
+Held in hand for 7 turn(s) → inked on turn 6
+
+**Game Result:** We lost. Final score: p1=12, p2=20. Winner: p2.

--- a/output.example/example-narratives/heathcliff_stoic_butler/0xuebtpz-17.p1.d.txt
+++ b/output.example/example-narratives/heathcliff_stoic_butler/0xuebtpz-17.p1.d.txt
@@ -1,0 +1,16 @@
+**Heathcliff Stoic Butler** — Narrative
+
+**Turn 8:** My owner chose to ink Winnie The Pooh Hunny Wizard instead of me (I could still play). I was played onto the board.
+
+**Turn 9:** I waited in play.
+
+**Turn 10:** I gained the ability to challenge, quest. I challenged Simba Protective Cub.
+
+**Turn 11:** I was challenged by Prince Eric Dashing And Brave and banished.
+
+---
+
+**Arc:**
+Held in hand for 1 turn(s) → Played on turn 8 → 4 turn(s) in play → 1 challenge(s) made → challenged 1 time(s) → banished on turn 11
+
+**Game Result:** We lost. Final score: p1=12, p2=20. Winner: p2.

--- a/output.example/example-narratives/heathcliff_stoic_butler/0xuebtpz-18.p1.c.txt
+++ b/output.example/example-narratives/heathcliff_stoic_butler/0xuebtpz-18.p1.c.txt
@@ -1,0 +1,10 @@
+**Heathcliff Stoic Butler** — Narrative
+
+**Turn 0:** I was drawn into hand. I was inked, leaving the game permanently.
+
+---
+
+**Arc:**
+Held in hand for 1 turn(s) → inked on turn 0
+
+**Game Result:** We won. Final score: p1=20, p2=9. Winner: p1.

--- a/output.example/example-narratives/heathcliff_stoic_butler/0xuebtpz-18.p1.d.txt
+++ b/output.example/example-narratives/heathcliff_stoic_butler/0xuebtpz-18.p1.d.txt
@@ -1,0 +1,16 @@
+**Heathcliff Stoic Butler** — Narrative
+
+**Turn 8:** I was played onto the board.
+
+**Turn 9:** I waited in play.
+
+**Turn 10:** I gained the ability to challenge, quest. I challenged Robin Hood Beloved Outlaw.
+
+**Turn 11:** I was challenged by Aladdin Cornered Swordsman and banished.
+
+---
+
+**Arc:**
+Held in hand for 1 turn(s) → Played on turn 8 → 4 turn(s) in play → 1 challenge(s) made → challenged 1 time(s) → banished on turn 11
+
+**Game Result:** We won. Final score: p1=20, p2=9. Winner: p1.

--- a/output.example/example-narratives/mulan_free_spirit/0xuebtpz-1.p2.b.txt
+++ b/output.example/example-narratives/mulan_free_spirit/0xuebtpz-1.p2.b.txt
@@ -1,0 +1,30 @@
+**Mulan Free Spirit** — Narrative
+
+**Turn 0:** I was drawn into hand.
+
+**Turn 1:** I gained the ability to ink. My owner chose to ink Aladdin Cornered Swordsman instead of me.
+
+**Turn 2:** I waited in hand.
+
+**Turn 3:** I gained the ability to ink. My owner chose to ink Mickey Mouse Standard Bearer instead of me.
+
+**Turn 4:** I waited in hand.
+
+**Turn 5:** I gained the ability to ink. My owner chose to ink Jafar Royal Vizier instead of me. My owner chose to play Robin Hood Beloved Outlaw instead of me.
+
+**Turn 6:** I waited in hand.
+
+**Turn 7:** I gained the ability to ink, play. My owner chose to ink Robin Hood Beloved Outlaw instead of me (I could still play). I was played onto the board.
+
+**Turn 8:** I waited in play.
+
+**Turn 9:** I gained the ability to challenge, quest. I quested, becoming exerted. (p2 lore: 2 → 4)
+
+**Turn 10:** I was challenged by Luisa Madrigal Magically Strong One and banished.
+
+---
+
+**Arc:**
+Held in hand for 8 turn(s) → Played on turn 7 → 4 turn(s) in play → 1 quest(s) → challenged 1 time(s) → banished on turn 10
+
+**Game Result:** We won. Final score: p1=6, p2=20. Winner: p2.

--- a/output.example/example-narratives/mulan_free_spirit/0xuebtpz-1.p2.d.txt
+++ b/output.example/example-narratives/mulan_free_spirit/0xuebtpz-1.p2.d.txt
@@ -1,0 +1,10 @@
+**Mulan Free Spirit** — Narrative
+
+**Turn 15:** I was inked, leaving the game permanently.
+
+---
+
+**Arc:**
+Held in hand for 1 turn(s) → inked on turn 15
+
+**Game Result:** We won. Final score: p1=6, p2=20. Winner: p2.

--- a/output.example/example-narratives/mulan_free_spirit/0xuebtpz-10.p2.b.txt
+++ b/output.example/example-narratives/mulan_free_spirit/0xuebtpz-10.p2.b.txt
@@ -1,0 +1,24 @@
+**Mulan Free Spirit** — Narrative
+
+**Turn 0:** I was drawn into hand.
+
+**Turn 1:** I gained the ability to ink. My owner chose to ink Genie Satisfied Dragon instead of me.
+
+**Turn 2:** I waited in hand.
+
+**Turn 3:** I gained the ability to ink. My owner chose to ink Robin Hood Beloved Outlaw instead of me.
+
+**Turn 4:** I waited in hand.
+
+**Turn 5:** I gained the ability to ink. My owner chose to ink Aladdin Cornered Swordsman instead of me. My owner chose to play Simba Protective Cub instead of me.
+
+**Turn 6:** I waited in hand.
+
+**Turn 7:** I gained the ability to ink, play. My owner chose to play Mickey Mouse Standard Bearer instead of me (I could still ink). I was inked, leaving the game permanently.
+
+---
+
+**Arc:**
+Held in hand for 8 turn(s) → inked on turn 7
+
+**Game Result:** We lost. Final score: p1=20, p2=3. Winner: p1.

--- a/output.example/example-narratives/mulan_free_spirit/0xuebtpz-10.p2.d.txt
+++ b/output.example/example-narratives/mulan_free_spirit/0xuebtpz-10.p2.d.txt
@@ -1,0 +1,10 @@
+**Mulan Free Spirit** — Narrative
+
+**Turn 15:** I was inked, leaving the game permanently.
+
+---
+
+**Arc:**
+Held in hand for 1 turn(s) → inked on turn 15
+
+**Game Result:** We lost. Final score: p1=20, p2=3. Winner: p1.

--- a/output.example/example-narratives/mulan_free_spirit/0xuebtpz-11.p2.b.txt
+++ b/output.example/example-narratives/mulan_free_spirit/0xuebtpz-11.p2.b.txt
@@ -1,0 +1,32 @@
+**Mulan Free Spirit** — Narrative
+
+**Turn 0:** I was drawn into hand.
+
+**Turn 1:** I gained the ability to ink. My owner chose to ink Robin Hood Beloved Outlaw instead of me.
+
+**Turn 2:** I waited in hand.
+
+**Turn 3:** I gained the ability to ink. My owner chose to ink Mickey Mouse Standard Bearer instead of me.
+
+**Turn 4:** I waited in hand.
+
+**Turn 5:** I gained the ability to ink. My owner chose to ink Mickey Mouse Standard Bearer instead of me.
+
+**Turn 6:** I waited in hand.
+
+**Turn 7:** I gained the ability to ink, play. My owner chose to play Jafar Royal Vizier instead of me (I could still ink). My owner chose to ink Robin Hood Beloved Outlaw instead of me.
+
+**Turn 8:** I waited in hand.
+
+**Turn 9:** I gained the ability to ink, play. My owner chose to play Prince Eric Dashing And Brave instead of me (I could still ink). My owner chose to ink Genie Satisfied Dragon instead of me. I was played onto the board.
+
+**Turn 10:** I waited in play.
+
+**Turn 11:** I gained the ability to challenge, quest. I challenged Luisa Madrigal Magically Strong One.
+
+---
+
+**Arc:**
+Held in hand for 10 turn(s) → Played on turn 9 → 3 turn(s) in play → 1 challenge(s) made
+
+**Game Result:** We lost. Final score: p1=21, p2=7. Winner: p1.

--- a/output.example/example-narratives/mulan_free_spirit/0xuebtpz-11.p2.d.txt
+++ b/output.example/example-narratives/mulan_free_spirit/0xuebtpz-11.p2.d.txt
@@ -1,0 +1,16 @@
+**Mulan Free Spirit** — Narrative
+
+**Turn 15:** I was played onto the board.
+
+**Turn 16:** I waited in play.
+
+**Turn 17:** I gained the ability to challenge, quest. I challenged Pinocchio Star Attraction.
+
+**Turn 18:** I was challenged by Luisa Madrigal Magically Strong One and banished.
+
+---
+
+**Arc:**
+Held in hand for 1 turn(s) → Played on turn 15 → 4 turn(s) in play → 1 challenge(s) made → challenged 1 time(s) → banished on turn 18
+
+**Game Result:** We lost. Final score: p1=21, p2=7. Winner: p1.

--- a/output.example/example-narratives/mulan_free_spirit/0xuebtpz-12.p2.b.txt
+++ b/output.example/example-narratives/mulan_free_spirit/0xuebtpz-12.p2.b.txt
@@ -1,0 +1,28 @@
+**Mulan Free Spirit** — Narrative
+
+**Turn 0:** I was drawn into hand.
+
+**Turn 1:** I gained the ability to ink. My owner chose to ink Mickey Mouse Standard Bearer instead of me.
+
+**Turn 2:** I waited in hand.
+
+**Turn 3:** I gained the ability to ink. My owner chose to ink Simba Protective Cub instead of me.
+
+**Turn 4:** I waited in hand.
+
+**Turn 5:** I gained the ability to ink. My owner chose to ink Jafar Royal Vizier instead of me. I was played onto the board.
+
+**Turn 6:** I waited in play.
+
+**Turn 7:** I gained the ability to challenge, quest. I quested, becoming exerted. (p2 lore: 1 → 3)
+
+**Turn 8:** I waited in play.
+
+**Turn 9:** I readied at the start of the turn. I challenged The White Rose Jewel Of The Garden.
+
+---
+
+**Arc:**
+Held in hand for 6 turn(s) → Played on turn 5 → 5 turn(s) in play → 1 quest(s) → 1 challenge(s) made
+
+**Game Result:** We lost. Final score: p1=20, p2=8. Winner: p1.

--- a/output.example/example-narratives/mulan_free_spirit/0xuebtpz-12.p2.d.txt
+++ b/output.example/example-narratives/mulan_free_spirit/0xuebtpz-12.p2.d.txt
@@ -1,0 +1,10 @@
+**Mulan Free Spirit** — Narrative
+
+**Turn 15:** I was inked, leaving the game permanently.
+
+---
+
+**Arc:**
+Held in hand for 1 turn(s) → inked on turn 15
+
+**Game Result:** We lost. Final score: p1=20, p2=8. Winner: p1.

--- a/output.example/example-narratives/mulan_free_spirit/0xuebtpz-13.p2.b.txt
+++ b/output.example/example-narratives/mulan_free_spirit/0xuebtpz-13.p2.b.txt
@@ -1,0 +1,20 @@
+**Mulan Free Spirit** — Narrative
+
+**Turn 0:** I was drawn into hand.
+
+**Turn 1:** I gained the ability to ink. My owner chose to ink Robin Hood Beloved Outlaw instead of me.
+
+**Turn 2:** I waited in hand.
+
+**Turn 3:** I gained the ability to ink. My owner chose to ink Simba Protective Cub instead of me.
+
+**Turn 4:** I waited in hand.
+
+**Turn 5:** I gained the ability to ink. I was inked, leaving the game permanently.
+
+---
+
+**Arc:**
+Held in hand for 6 turn(s) → inked on turn 5
+
+**Game Result:** We won. Final score: p1=13, p2=20. Winner: p2.

--- a/output.example/example-narratives/mulan_free_spirit/0xuebtpz-13.p2.d.txt
+++ b/output.example/example-narratives/mulan_free_spirit/0xuebtpz-13.p2.d.txt
@@ -1,0 +1,10 @@
+**Mulan Free Spirit** — Narrative
+
+**Turn 15:** I was inked, leaving the game permanently.
+
+---
+
+**Arc:**
+Held in hand for 1 turn(s) → inked on turn 15
+
+**Game Result:** We won. Final score: p1=13, p2=20. Winner: p2.

--- a/output.example/example-narratives/mulan_free_spirit/0xuebtpz-14.p2.a.txt
+++ b/output.example/example-narratives/mulan_free_spirit/0xuebtpz-14.p2.a.txt
@@ -1,0 +1,10 @@
+**Mulan Free Spirit** — Narrative
+
+**Turn 35:** I was inked, leaving the game permanently.
+
+---
+
+**Arc:**
+Held in hand for 1 turn(s) → inked on turn 35
+
+**Game Result:** We lost. Final score: p1=20, p2=17. Winner: p1.

--- a/output.example/example-narratives/mulan_free_spirit/0xuebtpz-14.p2.b.txt
+++ b/output.example/example-narratives/mulan_free_spirit/0xuebtpz-14.p2.b.txt
@@ -1,0 +1,20 @@
+**Mulan Free Spirit** — Narrative
+
+**Turn 0:** I was drawn into hand.
+
+**Turn 1:** I gained the ability to ink. My owner chose to ink Genie Satisfied Dragon instead of me.
+
+**Turn 2:** I waited in hand.
+
+**Turn 3:** I gained the ability to ink. My owner chose to ink Jafar Royal Vizier instead of me.
+
+**Turn 4:** I waited in hand.
+
+**Turn 5:** I gained the ability to ink. I was inked, leaving the game permanently.
+
+---
+
+**Arc:**
+Held in hand for 6 turn(s) → inked on turn 5
+
+**Game Result:** We lost. Final score: p1=20, p2=17. Winner: p1.

--- a/output.example/example-narratives/mulan_free_spirit/0xuebtpz-14.p2.d.txt
+++ b/output.example/example-narratives/mulan_free_spirit/0xuebtpz-14.p2.d.txt
@@ -1,0 +1,16 @@
+**Mulan Free Spirit** — Narrative
+
+**Turn 15:** I was played onto the board.
+
+**Turn 16:** I waited in play.
+
+**Turn 17:** I gained the ability to challenge, quest. My owner chose to challenge Robin Hood Beloved Outlaw instead of me (I could still quest). I quested, becoming exerted. (p2 lore: 9 → 11)
+
+**Turn 18:** I was challenged by Aladdin Prince Ali, taking 2 damage. I was challenged by Luisa Madrigal Magically Strong One and banished.
+
+---
+
+**Arc:**
+Held in hand for 1 turn(s) → Played on turn 15 → 4 turn(s) in play → 1 quest(s) → challenged 2 time(s) → 2 damage taken → banished on turn 18
+
+**Game Result:** We lost. Final score: p1=20, p2=17. Winner: p1.

--- a/output.example/example-narratives/mulan_free_spirit/0xuebtpz-15.p2.b.txt
+++ b/output.example/example-narratives/mulan_free_spirit/0xuebtpz-15.p2.b.txt
@@ -1,0 +1,38 @@
+**Mulan Free Spirit** — Narrative
+
+**Turn 0:** I was drawn into hand.
+
+**Turn 1:** I gained the ability to ink. My owner chose to ink Simba Protective Cub instead of me.
+
+**Turn 2:** I waited in hand.
+
+**Turn 3:** I gained the ability to ink. My owner chose to ink Jafar Royal Vizier instead of me.
+
+**Turn 4:** I waited in hand.
+
+**Turn 5:** I gained the ability to ink. My owner chose to ink Genie Satisfied Dragon instead of me. I was played onto the board.
+
+**Turn 6:** I waited in play.
+
+**Turn 7:** I gained the ability to quest. I quested, becoming exerted. (p2 lore: 2 → 4)
+
+**Turn 8:** I was challenged by Maleficent Sorceress, taking 2 damage.
+
+**Turn 9:** I readied at the start of the turn. I quested, becoming exerted. (p2 lore: 6 → 8)
+
+**Turn 10:** I waited in play.
+
+**Turn 11:** I readied at the start of the turn. I quested, becoming exerted. (p2 lore: 10 → 12)
+
+**Turn 12:** I waited in play.
+
+**Turn 13:** I readied at the start of the turn. My owner chose to challenge Robin Hood Beloved Outlaw instead of me (I could still quest). I quested, becoming exerted. (p2 lore: 13 → 15)
+
+**Turn 14:** I was challenged by Tinker Bell Fast Flier and banished.
+
+---
+
+**Arc:**
+Held in hand for 6 turn(s) → Played on turn 5 → 10 turn(s) in play → 4 quest(s) → challenged 2 time(s) → 2 damage taken → banished on turn 14
+
+**Game Result:** We won. Final score: p1=7, p2=20. Winner: p2.

--- a/output.example/example-narratives/mulan_free_spirit/0xuebtpz-15.p2.d.txt
+++ b/output.example/example-narratives/mulan_free_spirit/0xuebtpz-15.p2.d.txt
@@ -1,0 +1,14 @@
+**Mulan Free Spirit** — Narrative
+
+**Turn 15:** I was played onto the board.
+
+**Turn 16:** I waited in play.
+
+**Turn 17:** I gained the ability to quest. I quested, becoming exerted. (p2 lore: 18 → 20)
+
+---
+
+**Arc:**
+Held in hand for 1 turn(s) → Played on turn 15 → 3 turn(s) in play → 1 quest(s) → survived to end
+
+**Game Result:** We won. Final score: p1=7, p2=20. Winner: p2.

--- a/output.example/example-narratives/mulan_free_spirit/0xuebtpz-16.p2.b.txt
+++ b/output.example/example-narratives/mulan_free_spirit/0xuebtpz-16.p2.b.txt
@@ -1,0 +1,34 @@
+**Mulan Free Spirit** — Narrative
+
+**Turn 0:** I was drawn into hand.
+
+**Turn 1:** I gained the ability to ink. My owner chose to ink Robin Hood Beloved Outlaw instead of me.
+
+**Turn 2:** I waited in hand.
+
+**Turn 3:** I gained the ability to ink. My owner chose to ink Jafar Royal Vizier instead of me.
+
+**Turn 4:** I waited in hand.
+
+**Turn 5:** I gained the ability to ink. My owner chose to ink Aladdin Cornered Swordsman instead of me. My owner chose to play Mickey Mouse Standard Bearer instead of me.
+
+**Turn 6:** I waited in hand.
+
+**Turn 7:** I gained the ability to ink, play. My owner chose to ink Genie Satisfied Dragon instead of me (I could still play). I was played onto the board.
+
+**Turn 8:** I waited in play.
+
+**Turn 9:** I gained the ability to quest. I quested, becoming exerted. (p2 lore: 2 → 4)
+
+**Turn 10:** I waited in play.
+
+**Turn 11:** I readied at the start of the turn. My owner chose to challenge Prince Eric Dashing And Brave instead of me (I could still quest). I quested, becoming exerted. (p2 lore: 7 → 9)
+
+**Turn 12:** I was challenged by Luisa Madrigal Magically Strong One and banished.
+
+---
+
+**Arc:**
+Held in hand for 8 turn(s) → Played on turn 7 → 6 turn(s) in play → 2 quest(s) → challenged 1 time(s) → banished on turn 12
+
+**Game Result:** We lost. Final score: p1=20, p2=15. Winner: p1.

--- a/output.example/example-narratives/mulan_free_spirit/0xuebtpz-16.p2.d.txt
+++ b/output.example/example-narratives/mulan_free_spirit/0xuebtpz-16.p2.d.txt
@@ -1,0 +1,10 @@
+**Mulan Free Spirit** — Narrative
+
+**Turn 15:** I was inked, leaving the game permanently.
+
+---
+
+**Arc:**
+Held in hand for 1 turn(s) → inked on turn 15
+
+**Game Result:** We lost. Final score: p1=20, p2=15. Winner: p1.

--- a/output.example/example-narratives/mulan_free_spirit/0xuebtpz-17.p2.b.txt
+++ b/output.example/example-narratives/mulan_free_spirit/0xuebtpz-17.p2.b.txt
@@ -1,0 +1,28 @@
+**Mulan Free Spirit** — Narrative
+
+**Turn 0:** I was drawn into hand.
+
+**Turn 1:** I gained the ability to ink. My owner chose to ink Genie Satisfied Dragon instead of me.
+
+**Turn 2:** I waited in hand.
+
+**Turn 3:** I gained the ability to ink. My owner chose to ink Jafar Royal Vizier instead of me.
+
+**Turn 4:** I waited in hand.
+
+**Turn 5:** I gained the ability to ink. My owner chose to ink Mickey Mouse Standard Bearer instead of me. My owner chose to play Aladdin Cornered Swordsman instead of me.
+
+**Turn 6:** I waited in hand.
+
+**Turn 7:** I gained the ability to ink, play. My owner chose to ink Mickey Mouse Standard Bearer instead of me (I could still play). My owner chose to play Simba Protective Cub instead of me.
+
+**Turn 8:** I waited in hand.
+
+**Turn 9:** I gained the ability to ink, play. My owner chose to play Prince Eric Dashing And Brave instead of me (I could still ink). I was inked, leaving the game permanently.
+
+---
+
+**Arc:**
+Held in hand for 10 turn(s) → inked on turn 9
+
+**Game Result:** We won. Final score: p1=12, p2=20. Winner: p2.

--- a/output.example/example-narratives/mulan_free_spirit/0xuebtpz-17.p2.d.txt
+++ b/output.example/example-narratives/mulan_free_spirit/0xuebtpz-17.p2.d.txt
@@ -1,0 +1,16 @@
+**Mulan Free Spirit** — Narrative
+
+**Turn 15:** I was played onto the board.
+
+**Turn 16:** I waited in play.
+
+**Turn 17:** I gained the ability to quest. I quested, becoming exerted. (p2 lore: 11 → 13)
+
+**Turn 18:** I was challenged by Luisa Madrigal Magically Strong One and banished.
+
+---
+
+**Arc:**
+Held in hand for 1 turn(s) → Played on turn 15 → 4 turn(s) in play → 1 quest(s) → challenged 1 time(s) → banished on turn 18
+
+**Game Result:** We won. Final score: p1=12, p2=20. Winner: p2.

--- a/output.example/example-narratives/mulan_free_spirit/0xuebtpz-18.p2.b.txt
+++ b/output.example/example-narratives/mulan_free_spirit/0xuebtpz-18.p2.b.txt
@@ -1,0 +1,12 @@
+**Mulan Free Spirit** — Narrative
+
+**Turn 0:** I was drawn into hand.
+
+**Turn 1:** I gained the ability to ink. I was inked, leaving the game permanently.
+
+---
+
+**Arc:**
+Held in hand for 2 turn(s) → inked on turn 1
+
+**Game Result:** We lost. Final score: p1=20, p2=9. Winner: p1.

--- a/output.example/example-narratives/prince_eric_dashing_and_brave/0xuebtpz-1.p2.b.txt
+++ b/output.example/example-narratives/prince_eric_dashing_and_brave/0xuebtpz-1.p2.b.txt
@@ -1,0 +1,26 @@
+**Prince Eric Dashing And Brave** — Narrative
+
+**Turn 9:** I was played onto the board.
+
+**Turn 10:** I waited in play.
+
+**Turn 11:** I gained the ability to quest. I quested, becoming exerted. (p2 lore: 5 → 6)
+
+**Turn 12:** I was challenged by Tinker Bell Fast Flier, taking 1 damage. I was challenged by Pinocchio Star Attraction, taking 2 damage.
+
+**Turn 13:** I readied at the start of the turn. I quested, becoming exerted. (p2 lore: 10 → 11)
+
+**Turn 14:** I waited in play.
+
+**Turn 15:** I readied at the start of the turn. I quested, becoming exerted. (p2 lore: 13 → 14)
+
+**Turn 16:** I waited in play.
+
+**Turn 17:** I readied at the start of the turn. I quested, becoming exerted. (p2 lore: 16 → 17)
+
+---
+
+**Arc:**
+Held in hand for 1 turn(s) → Played on turn 9 → 9 turn(s) in play → 4 quest(s) → challenged 2 time(s) → 2 damage taken → survived to end
+
+**Game Result:** We won. Final score: p1=6, p2=20. Winner: p2.

--- a/output.example/example-narratives/prince_eric_dashing_and_brave/0xuebtpz-10.p2.b.txt
+++ b/output.example/example-narratives/prince_eric_dashing_and_brave/0xuebtpz-10.p2.b.txt
@@ -1,0 +1,10 @@
+**Prince Eric Dashing And Brave** — Narrative
+
+**Turn 9:** I was inked, leaving the game permanently.
+
+---
+
+**Arc:**
+Held in hand for 1 turn(s) → inked on turn 9
+
+**Game Result:** We lost. Final score: p1=20, p2=3. Winner: p1.

--- a/output.example/example-narratives/prince_eric_dashing_and_brave/0xuebtpz-11.p2.b.txt
+++ b/output.example/example-narratives/prince_eric_dashing_and_brave/0xuebtpz-11.p2.b.txt
@@ -1,0 +1,14 @@
+**Prince Eric Dashing And Brave** — Narrative
+
+**Turn 9:** I was played onto the board.
+
+**Turn 10:** I waited in play.
+
+**Turn 11:** I gained the ability to challenge, quest. I challenged The White Rose Jewel Of The Garden.
+
+---
+
+**Arc:**
+Held in hand for 1 turn(s) → Played on turn 9 → 3 turn(s) in play → 1 challenge(s) made
+
+**Game Result:** We lost. Final score: p1=21, p2=7. Winner: p1.

--- a/output.example/example-narratives/prince_eric_dashing_and_brave/0xuebtpz-11.p2.c.txt
+++ b/output.example/example-narratives/prince_eric_dashing_and_brave/0xuebtpz-11.p2.c.txt
@@ -1,0 +1,14 @@
+**Prince Eric Dashing And Brave** — Narrative
+
+**Turn 23:** I was played onto the board.
+
+**Turn 24:** I waited in play.
+
+**Turn 25:** I gained the ability to challenge, quest. I challenged Luisa Madrigal Magically Strong One.
+
+---
+
+**Arc:**
+Held in hand for 1 turn(s) → Played on turn 23 → 3 turn(s) in play → 1 challenge(s) made
+
+**Game Result:** We lost. Final score: p1=21, p2=7. Winner: p1.

--- a/output.example/example-narratives/prince_eric_dashing_and_brave/0xuebtpz-12.p2.b.txt
+++ b/output.example/example-narratives/prince_eric_dashing_and_brave/0xuebtpz-12.p2.b.txt
@@ -1,0 +1,10 @@
+**Prince Eric Dashing And Brave** — Narrative
+
+**Turn 9:** I was inked, leaving the game permanently.
+
+---
+
+**Arc:**
+Held in hand for 1 turn(s) → inked on turn 9
+
+**Game Result:** We lost. Final score: p1=20, p2=8. Winner: p1.

--- a/output.example/example-narratives/prince_eric_dashing_and_brave/0xuebtpz-13.p2.b.txt
+++ b/output.example/example-narratives/prince_eric_dashing_and_brave/0xuebtpz-13.p2.b.txt
@@ -1,0 +1,32 @@
+**Prince Eric Dashing And Brave** — Narrative
+
+**Turn 9:** I was played onto the board.
+
+**Turn 10:** I waited in play.
+
+**Turn 11:** I gained the ability to challenge, quest. My owner chose to challenge Aladdin Cornered Swordsman instead of me (I could still quest). I quested, becoming exerted. (p2 lore: 7 → 8)
+
+**Turn 12:** I was challenged by Pinocchio Star Attraction, taking 1 damage.
+
+**Turn 13:** I readied at the start of the turn. I quested, becoming exerted. (p2 lore: 8 → 9)
+
+**Turn 14:** I waited in play.
+
+**Turn 15:** I readied at the start of the turn. I quested, becoming exerted. (p2 lore: 11 → 12)
+
+**Turn 16:** I waited in play.
+
+**Turn 17:** I readied at the start of the turn. I quested, becoming exerted. (p2 lore: 12 → 13)
+
+**Turn 18:** I waited in play.
+
+**Turn 19:** I readied at the start of the turn. I quested, becoming exerted. (p2 lore: 14 → 15)
+
+**Turn 20:** I was challenged by Luisa Madrigal Magically Strong One and banished.
+
+---
+
+**Arc:**
+Held in hand for 1 turn(s) → Played on turn 9 → 12 turn(s) in play → 5 quest(s) → challenged 2 time(s) → 1 damage taken → banished on turn 20
+
+**Game Result:** We won. Final score: p1=13, p2=20. Winner: p2.

--- a/output.example/example-narratives/prince_eric_dashing_and_brave/0xuebtpz-13.p2.c.txt
+++ b/output.example/example-narratives/prince_eric_dashing_and_brave/0xuebtpz-13.p2.c.txt
@@ -1,0 +1,18 @@
+**Prince Eric Dashing And Brave** — Narrative
+
+**Turn 23:** I was played onto the board.
+
+**Turn 24:** I waited in play.
+
+**Turn 25:** I gained the ability to challenge, quest. My owner chose to challenge Chien Po Imperial Soldier instead of me (I could still quest). I quested, becoming exerted. (p2 lore: 17 → 18)
+
+**Turn 26:** I waited in play.
+
+**Turn 27:** I readied at the start of the turn. My owner chose to challenge Chien Po Imperial Soldier instead of me (I could still quest). I quested, becoming exerted. (p2 lore: 18 → 19)
+
+---
+
+**Arc:**
+Held in hand for 1 turn(s) → Played on turn 23 → 5 turn(s) in play → 2 quest(s) → survived to end
+
+**Game Result:** We won. Final score: p1=13, p2=20. Winner: p2.

--- a/output.example/example-narratives/prince_eric_dashing_and_brave/0xuebtpz-14.p2.a.txt
+++ b/output.example/example-narratives/prince_eric_dashing_and_brave/0xuebtpz-14.p2.a.txt
@@ -1,0 +1,18 @@
+**Prince Eric Dashing And Brave** — Narrative
+
+**Turn 29:** I was played onto the board.
+
+**Turn 30:** I waited in play.
+
+**Turn 31:** I gained the ability to challenge, quest. My owner chose to challenge Chien Po Imperial Soldier instead of me (I could still quest). I quested, becoming exerted. (p2 lore: 16 → 17)
+
+**Turn 32:** I waited in play.
+
+**Turn 33:** I readied at the start of the turn. I challenged Tor Florist.
+
+---
+
+**Arc:**
+Held in hand for 1 turn(s) → Played on turn 29 → 5 turn(s) in play → 1 quest(s) → 1 challenge(s) made
+
+**Game Result:** We lost. Final score: p1=20, p2=17. Winner: p1.

--- a/output.example/example-narratives/prince_eric_dashing_and_brave/0xuebtpz-14.p2.b.txt
+++ b/output.example/example-narratives/prince_eric_dashing_and_brave/0xuebtpz-14.p2.b.txt
@@ -1,0 +1,14 @@
+**Prince Eric Dashing And Brave** — Narrative
+
+**Turn 9:** I was played onto the board.
+
+**Turn 10:** I waited in play.
+
+**Turn 11:** I gained the ability to challenge, quest. I challenged Heathcliff Stoic Butler.
+
+---
+
+**Arc:**
+Held in hand for 1 turn(s) → Played on turn 9 → 3 turn(s) in play → 1 challenge(s) made
+
+**Game Result:** We lost. Final score: p1=20, p2=17. Winner: p1.

--- a/output.example/example-narratives/prince_eric_dashing_and_brave/0xuebtpz-14.p2.c.txt
+++ b/output.example/example-narratives/prince_eric_dashing_and_brave/0xuebtpz-14.p2.c.txt
@@ -1,0 +1,10 @@
+**Prince Eric Dashing And Brave** — Narrative
+
+**Turn 23:** I was inked, leaving the game permanently.
+
+---
+
+**Arc:**
+Held in hand for 1 turn(s) → inked on turn 23
+
+**Game Result:** We lost. Final score: p1=20, p2=17. Winner: p1.

--- a/output.example/example-narratives/prince_eric_dashing_and_brave/0xuebtpz-14.p2.d.txt
+++ b/output.example/example-narratives/prince_eric_dashing_and_brave/0xuebtpz-14.p2.d.txt
@@ -1,0 +1,14 @@
+**Prince Eric Dashing And Brave** — Narrative
+
+**Turn 33:** I was played onto the board.
+
+**Turn 34:** I waited in play.
+
+**Turn 35:** I gained the ability to challenge, quest. I challenged Winnie The Pooh Hunny Wizard.
+
+---
+
+**Arc:**
+Held in hand for 1 turn(s) → Played on turn 33 → 3 turn(s) in play → 1 challenge(s) made
+
+**Game Result:** We lost. Final score: p1=20, p2=17. Winner: p1.

--- a/output.example/example-narratives/prince_eric_dashing_and_brave/0xuebtpz-15.p2.b.txt
+++ b/output.example/example-narratives/prince_eric_dashing_and_brave/0xuebtpz-15.p2.b.txt
@@ -1,0 +1,14 @@
+**Prince Eric Dashing And Brave** — Narrative
+
+**Turn 9:** My owner chose to ink Aladdin Cornered Swordsman instead of me (I could still play). I was played onto the board.
+
+**Turn 10:** I waited in play.
+
+**Turn 11:** I gained the ability to challenge, quest. I challenged The White Rose Jewel Of The Garden.
+
+---
+
+**Arc:**
+Held in hand for 1 turn(s) → Played on turn 9 → 3 turn(s) in play → 1 challenge(s) made
+
+**Game Result:** We won. Final score: p1=7, p2=20. Winner: p2.

--- a/output.example/example-narratives/prince_eric_dashing_and_brave/0xuebtpz-16.p2.b.txt
+++ b/output.example/example-narratives/prince_eric_dashing_and_brave/0xuebtpz-16.p2.b.txt
@@ -1,0 +1,14 @@
+**Prince Eric Dashing And Brave** — Narrative
+
+**Turn 9:** I was played onto the board.
+
+**Turn 10:** I waited in play.
+
+**Turn 11:** I gained the ability to challenge, quest. I challenged Heathcliff Stoic Butler.
+
+---
+
+**Arc:**
+Held in hand for 1 turn(s) → Played on turn 9 → 3 turn(s) in play → 1 challenge(s) made
+
+**Game Result:** We lost. Final score: p1=20, p2=15. Winner: p1.

--- a/output.example/example-narratives/prince_eric_dashing_and_brave/0xuebtpz-17.p2.a.txt
+++ b/output.example/example-narratives/prince_eric_dashing_and_brave/0xuebtpz-17.p2.a.txt
@@ -1,0 +1,10 @@
+**Prince Eric Dashing And Brave** — Narrative
+
+**Turn 29:** I was inked, leaving the game permanently.
+
+---
+
+**Arc:**
+Held in hand for 1 turn(s) → inked on turn 29
+
+**Game Result:** We won. Final score: p1=12, p2=20. Winner: p2.

--- a/output.example/example-narratives/prince_eric_dashing_and_brave/0xuebtpz-17.p2.b.txt
+++ b/output.example/example-narratives/prince_eric_dashing_and_brave/0xuebtpz-17.p2.b.txt
@@ -1,0 +1,14 @@
+**Prince Eric Dashing And Brave** — Narrative
+
+**Turn 9:** I was played onto the board.
+
+**Turn 10:** I waited in play.
+
+**Turn 11:** I gained the ability to challenge, quest. I challenged Heathcliff Stoic Butler.
+
+---
+
+**Arc:**
+Held in hand for 1 turn(s) → Played on turn 9 → 3 turn(s) in play → 1 challenge(s) made
+
+**Game Result:** We won. Final score: p1=12, p2=20. Winner: p2.

--- a/output.example/example-narratives/prince_eric_dashing_and_brave/0xuebtpz-17.p2.c.txt
+++ b/output.example/example-narratives/prince_eric_dashing_and_brave/0xuebtpz-17.p2.c.txt
@@ -1,0 +1,20 @@
+**Prince Eric Dashing And Brave** — Narrative
+
+**Turn 23:** I was played onto the board.
+
+**Turn 24:** I waited in play.
+
+**Turn 25:** I gained the ability to challenge, quest. I challenged Pinocchio Star Attraction.
+
+**Turn 26:** I waited in play.
+
+**Turn 27:** I readied at the start of the turn. I quested, becoming exerted. (p2 lore: 16 → 17)
+
+**Turn 28:** I was challenged by The White Rose Jewel Of The Garden and banished.
+
+---
+
+**Arc:**
+Held in hand for 1 turn(s) → Played on turn 23 → 6 turn(s) in play → 1 quest(s) → 1 challenge(s) made → challenged 1 time(s) → banished on turn 28
+
+**Game Result:** We won. Final score: p1=12, p2=20. Winner: p2.

--- a/output.example/example-narratives/prince_eric_dashing_and_brave/0xuebtpz-18.p2.b.txt
+++ b/output.example/example-narratives/prince_eric_dashing_and_brave/0xuebtpz-18.p2.b.txt
@@ -1,0 +1,10 @@
+**Prince Eric Dashing And Brave** — Narrative
+
+**Turn 9:** I was inked, leaving the game permanently.
+
+---
+
+**Arc:**
+Held in hand for 1 turn(s) → inked on turn 9
+
+**Game Result:** We lost. Final score: p1=20, p2=9. Winner: p1.

--- a/output.example/example-narratives/prince_eric_dashing_and_brave/0xuebtpz-18.p2.c.txt
+++ b/output.example/example-narratives/prince_eric_dashing_and_brave/0xuebtpz-18.p2.c.txt
@@ -1,0 +1,10 @@
+**Prince Eric Dashing And Brave** — Narrative
+
+**Turn 23:** I was inked, leaving the game permanently.
+
+---
+
+**Arc:**
+Held in hand for 1 turn(s) → inked on turn 23
+
+**Game Result:** We lost. Final score: p1=20, p2=9. Winner: p1.

--- a/output.example/example-narratives/prince_eric_dashing_and_brave/0xuebtpz-19.p2.b.txt
+++ b/output.example/example-narratives/prince_eric_dashing_and_brave/0xuebtpz-19.p2.b.txt
@@ -1,0 +1,14 @@
+**Prince Eric Dashing And Brave** — Narrative
+
+**Turn 9:** My owner chose to ink Mickey Mouse Standard Bearer instead of me (I could still play). I was played onto the board.
+
+**Turn 10:** I waited in play.
+
+**Turn 11:** I gained the ability to challenge, quest. I challenged Luisa Madrigal Magically Strong One.
+
+---
+
+**Arc:**
+Held in hand for 1 turn(s) → Played on turn 9 → 3 turn(s) in play → 1 challenge(s) made
+
+**Game Result:** We lost. Final score: p1=20, p2=10. Winner: p1.

--- a/output.example/example-narratives/prince_eric_dashing_and_brave/0xuebtpz-19.p2.c.txt
+++ b/output.example/example-narratives/prince_eric_dashing_and_brave/0xuebtpz-19.p2.c.txt
@@ -1,0 +1,12 @@
+**Prince Eric Dashing And Brave** — Narrative
+
+**Turn 23:** I was played onto the board.
+
+**Turn 24:** I waited in play.
+
+---
+
+**Arc:**
+Held in hand for 1 turn(s) → Played on turn 23 → 2 turn(s) in play → survived to end
+
+**Game Result:** We lost. Final score: p1=20, p2=10. Winner: p1.


### PR DESCRIPTION
  - Add bin/build-trajectories.py to extract per-card JSONL from episodes
  - Add bin/trajectory-story.py for structured and narrative story formats
  - Add bin/build-narratives.py for batch processing across all episodes
  - Track card roles (actor/target/byproduct/observer) per action
  - Include lore deltas, game results, and decision points in output
  - Output to output/narratives/{card_label}/{episode}.{player}.{instance}.txt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added narrative generation system for game cards, producing turn-by-turn story outputs with game context, card arc progression, and final results.

* **Chores**
  * Added build commands for trajectory data extraction and narrative generation workflows.
  * Included example narrative outputs demonstrating the story format.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->